### PR TITLE
ops: set enableOpenApiToPostman to false

### DIFF
--- a/.github/workflows/release-on-tag-push.yaml
+++ b/.github/workflows/release-on-tag-push.yaml
@@ -11,4 +11,3 @@ jobs:
     secrets: inherit
     with:
       enableOpenApiToPostman: false
-         

--- a/.github/workflows/release-on-tag-push.yaml
+++ b/.github/workflows/release-on-tag-push.yaml
@@ -9,3 +9,8 @@ jobs:
   release_on_tag_push:
     uses: MapColonies/shared-workflows/.github/workflows/release-on-tag-push.yaml@v2
     secrets: inherit
+    with:
+      enableOpenApiToPostman: false
+    
+
+

--- a/.github/workflows/release-on-tag-push.yaml
+++ b/.github/workflows/release-on-tag-push.yaml
@@ -11,6 +11,4 @@ jobs:
     secrets: inherit
     with:
       enableOpenApiToPostman: false
-    
-
-
+         


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            |  ✖                                                                       |
| Ops         | ✔                                                                        |

Further  information:
Set enableOpenApiToPostman to false (worker service without openapi)
