### PR TITLE
fix: update job internalId with catalogId(MAPCO-5057)

### DIFF
--- a/src/job/models/newJobHandler.ts
+++ b/src/job/models/newJobHandler.ts
@@ -50,7 +50,10 @@ export class NewJobHandler implements IJobHandler {
       await this.taskBuilder.pushTasks(job.id, mergeTasks);
 
       logger.info({ msg: 'Updating job with new metadata', ...metadata, extendedLayerMetadata });
-      await this.queueClient.jobManagerClient.updateJob(job.id, { parameters: { metadata: extendedLayerMetadata, partData, inputFiles } });
+      await this.queueClient.jobManagerClient.updateJob(job.id, {
+        internalId: extendedLayerMetadata.catalogId,
+        parameters: { metadata: extendedLayerMetadata, partData, inputFiles },
+      });
 
       logger.info({ msg: 'Acking task' });
       await this.queueClient.ack(job.id, taskId);

--- a/tests/unit/job/newJobHandler/newJobHandler.spec.ts
+++ b/tests/unit/job/newJobHandler/newJobHandler.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/unbound-method */
 import { OperationStatus } from '@map-colonies/mc-priority-queue';
 import { finalizeTaskForIngestionNew } from '../../mocks/tasksMockData';
@@ -25,7 +26,10 @@ describe('NewJobHandler', () => {
 
       expect(taskBuilderMock.buildTasks).toHaveBeenCalled();
       expect(taskBuilderMock.pushTasks).toHaveBeenCalledWith(job.id, tasks);
-      expect(queueClientMock.jobManagerClient.updateJob).toHaveBeenCalled();
+      expect(queueClientMock.jobManagerClient.updateJob).toHaveBeenCalledWith(job.id, {
+        internalId: expect.any(String),
+        parameters: expect.any(Object),
+      });
       expect(queueClientMock.ack).toHaveBeenCalledWith(job.id, taskId);
     });
 


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |


Further  information:
newJobHandler: update job internalId with catalogId
