### PR TITLE
feat(tileMergeTaskManager): create buffered version of the unified parts

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -110,10 +110,11 @@
             "__name": "TILES_MERGING_TASK_BATCH_SIZE",
             "__format": "number"
           },
-          "radiusBufferCM": {
+          "radiusBuffer": {
             "__name": "TILES_MERGING_RADIUS_BUFFER_CM",
             "__format": "number"
-          }
+          },
+          "radiusBufferUnits": "TILES_MERGING_RADIUS_BUFFER_UNITS"
         },
         "tilesSeeding": {
           "type": "TILES_SEEDING_TASK_TYPE",

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -111,7 +111,7 @@
             "__format": "number"
           },
           "radiusBuffer": {
-            "__name": "TILES_MERGING_RADIUS_BUFFER_CM",
+            "__name": "TILES_MERGING_RADIUS_BUFFER",
             "__format": "number"
           },
           "radiusBufferUnits": "TILES_MERGING_RADIUS_BUFFER_UNITS"

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -109,6 +109,10 @@
           "taskBatchSize": {
             "__name": "TILES_MERGING_TASK_BATCH_SIZE",
             "__format": "number"
+          },
+          "radiusBufferCM": {
+            "__name": "TILES_MERGING_RADIUS_BUFFER_CM",
+            "__format": "number"
           }
         },
         "tilesSeeding": {

--- a/config/default.json
+++ b/config/default.json
@@ -86,7 +86,8 @@
           "type": "tiles-merging",
           "tileBatchSize": 10000,
           "taskBatchSize": 5,
-          "radiusBufferCM": 30
+          "radiusBuffer": 0.000006,
+          "radiusBufferUnits": "degrees"
         },
         "tilesSeeding": {
           "type": "tiles-seeding",

--- a/config/default.json
+++ b/config/default.json
@@ -85,7 +85,8 @@
         "tilesMerging": {
           "type": "tiles-merging",
           "tileBatchSize": 10000,
-          "taskBatchSize": 5
+          "taskBatchSize": 5,
+          "radiusBufferCM": 30
         },
         "tilesSeeding": {
           "type": "tiles-seeding",

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -46,7 +46,7 @@ data:
   TILES_MERGING_TASK_TYPE: {{ $jobDefinitions.tasks.merge.type | quote }}
   TILES_MERGING_TILE_BATCH_SIZE: {{ $jobDefinitions.tasks.merge.tileBatchSize | quote }}
   TILES_MERGING_TASK_BATCH_SIZE: {{ $jobDefinitions.tasks.merge.taskBatchSize | quote }}
-  TILES_MERGING_TASK_BATCH_SIZE: {{ $jobDefinitions.tasks.merge.radiusBufferCM | quote }}
+  TILES_MERGING_RADIUS_BUFFER_CM: {{ $jobDefinitions.tasks.merge.radiusBufferCM | quote }}
   TILES_SEEDING_TASK_TYPE: {{ $jobDefinitions.tasks.seed.type | quote }}
   TILES_SEEDING_GRID : {{ $jobDefinitions.tasks.seed.grid | quote }}
   TILES_SEEDING_MAX_ZOOM : {{ $jobDefinitions.tasks.seed.maxZoom | quote }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -46,6 +46,7 @@ data:
   TILES_MERGING_TASK_TYPE: {{ $jobDefinitions.tasks.merge.type | quote }}
   TILES_MERGING_TILE_BATCH_SIZE: {{ $jobDefinitions.tasks.merge.tileBatchSize | quote }}
   TILES_MERGING_TASK_BATCH_SIZE: {{ $jobDefinitions.tasks.merge.taskBatchSize | quote }}
+  TILES_MERGING_TASK_BATCH_SIZE: {{ $jobDefinitions.tasks.merge.radiusBufferCM | quote }}
   TILES_SEEDING_TASK_TYPE: {{ $jobDefinitions.tasks.seed.type | quote }}
   TILES_SEEDING_GRID : {{ $jobDefinitions.tasks.seed.grid | quote }}
   TILES_SEEDING_MAX_ZOOM : {{ $jobDefinitions.tasks.seed.maxZoom | quote }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -46,7 +46,7 @@ data:
   TILES_MERGING_TASK_TYPE: {{ $jobDefinitions.tasks.merge.type | quote }}
   TILES_MERGING_TILE_BATCH_SIZE: {{ $jobDefinitions.tasks.merge.tileBatchSize | quote }}
   TILES_MERGING_TASK_BATCH_SIZE: {{ $jobDefinitions.tasks.merge.taskBatchSize | quote }}
-  TILES_MERGING_RADIUS_BUFFER_CM: {{ $jobDefinitions.tasks.merge.radiusBuffer | quote }}
+  TILES_MERGING_RADIUS_BUFFER: {{ $jobDefinitions.tasks.merge.radiusBuffer | quote }}
   TILES_MERGING_RADIUS_BUFFER_UNITS: {{ $jobDefinitions.tasks.merge.radiusBufferUnits | quote }}
   TILES_SEEDING_TASK_TYPE: {{ $jobDefinitions.tasks.seed.type | quote }}
   TILES_SEEDING_GRID : {{ $jobDefinitions.tasks.seed.grid | quote }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -46,7 +46,8 @@ data:
   TILES_MERGING_TASK_TYPE: {{ $jobDefinitions.tasks.merge.type | quote }}
   TILES_MERGING_TILE_BATCH_SIZE: {{ $jobDefinitions.tasks.merge.tileBatchSize | quote }}
   TILES_MERGING_TASK_BATCH_SIZE: {{ $jobDefinitions.tasks.merge.taskBatchSize | quote }}
-  TILES_MERGING_RADIUS_BUFFER_CM: {{ $jobDefinitions.tasks.merge.radiusBufferCM | quote }}
+  TILES_MERGING_RADIUS_BUFFER_CM: {{ $jobDefinitions.tasks.merge.radiusBuffer | quote }}
+  TILES_MERGING_RADIUS_BUFFER_UNITS: {{ $jobDefinitions.tasks.merge.radiusBufferUnits | quote }}
   TILES_SEEDING_TASK_TYPE: {{ $jobDefinitions.tasks.seed.type | quote }}
   TILES_SEEDING_GRID : {{ $jobDefinitions.tasks.seed.grid | quote }}
   TILES_SEEDING_MAX_ZOOM : {{ $jobDefinitions.tasks.seed.maxZoom | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -123,6 +123,7 @@ jobDefinitions:
         type: ""
         tileBatchSize: 10000
         taskBatchSize: 5
+        radiusBufferCM: 30
       seed:
         type: ""
         grid: "WorldCRS84"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -123,7 +123,8 @@ jobDefinitions:
         type: ""
         tileBatchSize: 10000
         taskBatchSize: 5
-        radiusBufferCM: 30
+        radiusBuffer: 0.000006
+        radiusBufferUnits: "degrees" # supported values are: "degrees" | "centimeters" | "meters" | "millimeters" | "kilometers" | "miles" | "inches" | "yards" | "feet" | "radians"
       seed:
         type: ""
         grid: "WorldCRS84"

--- a/tests/configurations/unit/jest.config.js
+++ b/tests/configurations/unit/jest.config.js
@@ -30,7 +30,7 @@ module.exports = {
       branches: 80,
       functions: 80,
       lines: 80,
-      statements: -10,
+      statements: -12,
     },
   },
 };


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |


Further  information:
In order to solve the **Error**: `Unable to complete output ring starting at [[34.3212890625](tel:343212890625), 31.227936280461925]. Last matching segment found ends at [34.3409844, 31.230938900000005].`
We simplified the unified polygon with turf buffer function.
the settings we used are:  

- radius: 30 (configurable)
- unit: centimeters
