### PR TITLE
fix: prevent worker thread blocking during large polygon ingestion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,35 +1,27 @@
-// this import must be called before the first import of tsyringe
 import 'reflect-metadata';
+
 import { createServer } from 'http';
 import { createTerminus } from '@godaddy/terminus';
 import { Logger } from '@map-colonies/js-logger';
 import config from 'config';
 import { DEFAULT_SERVER_PORT, SERVICES } from './common/constants';
 import { getApp } from './app';
-import { JobProcessor } from './job/models/jobProcessor';
+import { PollingWorker } from './pollingWorker';
 
 const port: number = config.get<number>('server.port') || DEFAULT_SERVER_PORT;
-
 const [app, container] = getApp();
-
 const logger = container.resolve<Logger>(SERVICES.LOGGER);
+const pollingWorker = container.resolve(PollingWorker);
+
 const stubHealthCheck = async (): Promise<void> => Promise.resolve();
-// eslint-disable-next-line @typescript-eslint/naming-convention
-const server = createTerminus(createServer(app), { healthChecks: { '/liveness': stubHealthCheck, onSignal: container.resolve('onSignal') } });
 
-const jobProcessor = container.resolve(JobProcessor);
-
-async function startPolling(): Promise<void> {
-  await jobProcessor.start();
-}
+const server = createTerminus(createServer(app), {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  healthChecks: { '/liveness': stubHealthCheck },
+  onSignal: container.resolve('onSignal'),
+});
 
 server.listen(port, () => {
   logger.info(`app started on port ${port}`);
-  startPolling().catch((error) => {
-    if (error instanceof Error) {
-      logger.fatal({ msg: 'error in main loop', error: error.message });
-    }
-    jobProcessor.stop();
-    process.exit(1);
-  });
+  pollingWorker.start();
 });

--- a/src/job/models/newJobHandler.ts
+++ b/src/job/models/newJobHandler.ts
@@ -55,7 +55,6 @@ export class NewJobHandler extends JobHandler implements IJobHandler {
       logger.info({ msg: 'building tasks' });
       const mergeTasks = this.taskBuilder.buildTasks(taskBuildParams);
 
-      logger.info({ msg: 'pushing tasks' });
       await this.taskBuilder.pushTasks(job.id, job.type, mergeTasks);
 
       logger.info({ msg: 'Updating job with new metadata', ...metadata, extendedLayerMetadata });

--- a/src/job/models/swapJobHandler.ts
+++ b/src/job/models/swapJobHandler.ts
@@ -53,7 +53,6 @@ export class SwapJobHandler extends JobHandler implements IJobHandler {
       logger.info({ msg: 'building tasks' });
       const mergeTasks = this.taskBuilder.buildTasks(taskBuildParams);
 
-      logger.info({ msg: 'pushing tasks' });
       await this.taskBuilder.pushTasks(job.id, job.type, mergeTasks);
 
       logger.info({ msg: 'Acking task' });

--- a/src/job/models/updateJobHandler.ts
+++ b/src/job/models/updateJobHandler.ts
@@ -50,7 +50,6 @@ export class UpdateJobHandler extends JobHandler implements IJobHandler {
       logger.info({ msg: 'building tasks' });
       const mergeTasks = this.taskBuilder.buildTasks(taskBuildParams);
 
-      logger.info({ msg: 'pushing tasks' });
       await this.taskBuilder.pushTasks(job.id, job.type, mergeTasks);
 
       logger.info({ msg: 'Acking task' });

--- a/src/pollingWorker.ts
+++ b/src/pollingWorker.ts
@@ -1,0 +1,49 @@
+import { Worker } from 'worker_threads';
+import { join } from 'path';
+import { Logger } from '@map-colonies/js-logger';
+import { inject, injectable } from 'tsyringe';
+import { SERVICES } from './common/constants';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+export const messageTypes = {
+  START: 'START',
+  STOP: 'STOP',
+  ERROR: 'ERROR',
+} as const;
+/* eslint-enable @typescript-eslint/naming-convention */
+
+@injectable()
+export class PollingWorker {
+  private worker!: Worker;
+
+  public constructor(@inject(SERVICES.LOGGER) private readonly logger: Logger) {
+    this.initializeWorker();
+  }
+
+  public start(): void {
+    this.worker.postMessage({ type: messageTypes.START });
+  }
+
+  private stop(): void {
+    this.worker.postMessage({ type: messageTypes.STOP });
+  }
+
+  private initializeWorker(): void {
+    this.worker = new Worker(join(__dirname, 'worker.js'));
+
+    this.worker.on('message', (message: { type: string; error?: string }) => {
+      if (message.type === messageTypes.ERROR) {
+        this.logger.error('Polling error', { error: message.error });
+        this.stop();
+      }
+    });
+
+    this.worker.on('error', (error) => {
+      this.logger.error('Worker error', { error });
+    });
+
+    this.worker.on('exit', (code) => {
+      this.logger.warn('Worker exited with code', { code });
+    });
+  }
+}

--- a/src/pollingWorker.ts
+++ b/src/pollingWorker.ts
@@ -33,7 +33,7 @@ export class PollingWorker {
 
     this.worker.on('message', (message: { type: string; error?: string }) => {
       if (message.type === messageTypes.ERROR) {
-        this.logger.error('Polling error', { error: message.error });
+        this.logger.fatal('Polling error', { error: message.error });
         this.stop();
       }
     });

--- a/src/task/models/tileMergeTaskManager.ts
+++ b/src/task/models/tileMergeTaskManager.ts
@@ -77,14 +77,14 @@ export class TileMergeTaskManager {
         this.taskMetrics.trackTasksEnqueue(jobType, this.taskType, task.batches.length);
 
         if (taskBatch.length === this.taskBatchSize) {
-          logger.debug({ msg: 'Pushing task batch to queue', batchLength: taskBatch.length, taskBatch });
+          logger.info({ msg: 'Pushing task batch to queue', batchLength: taskBatch.length });
           await this.enqueueTasks(jobId, taskBatch);
           taskBatch = [];
         }
       }
 
       if (taskBatch.length > 0) {
-        logger.debug({ msg: 'Pushing last task batch to queue', batchLength: taskBatch.length, taskBatch });
+        logger.info({ msg: 'Pushing last task batch to queue', batchLength: taskBatch.length });
         await this.enqueueTasks(jobId, taskBatch);
       }
     } catch (error) {
@@ -191,10 +191,13 @@ export class TileMergeTaskManager {
   private async *createZoomLevelTasks(params: MergeParameters): AsyncGenerator<MergeTaskParameters, void, void> {
     const { ppCollection, taskMetadata, zoomDefinitions, tilesSource } = params;
     const { maxZoom, partsZoomLevelMatch } = zoomDefinitions;
+    const logger = this.logger.child({ taskType: this.taskType, maxZoom, partsZoomLevelMatch });
 
     let unifiedPart: UnifiedPart | null = partsZoomLevelMatch ? this.unifyParts(ppCollection, tilesSource) : null;
+    logger.info({ msg: 'Creating tasks for zoom levels' });
 
     for (let zoom = maxZoom; zoom >= 0; zoom--) {
+      logger.info({ msg: 'Processing zoom level', zoom });
       if (!partsZoomLevelMatch) {
         const filteredFeatures = ppCollection.features.filter((feature) => feature.properties.maxZoom >= zoom);
         const collection = featureCollection(filteredFeatures);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,31 @@
+import 'reflect-metadata';
+import { parentPort } from 'worker_threads';
+import { JobProcessor } from './job/models/jobProcessor';
+import { getApp } from './app';
+import { messageTypes } from './pollingWorker';
+
+// Initialize container in worker thread
+const [, workerContainer] = getApp();
+const jobProcessor = workerContainer.resolve(JobProcessor);
+
+async function startPolling(): Promise<void> {
+  try {
+    await jobProcessor.start();
+  } catch (error) {
+    if (error instanceof Error) {
+      parentPort?.postMessage({ type: messageTypes.ERROR, error: error.message });
+    }
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-misused-promises
+parentPort?.on('message', async (message: { type: string }) => {
+  switch (message.type) {
+    case messageTypes.START:
+      await startPolling();
+      break;
+    case messageTypes.STOP:
+      jobProcessor.stop();
+      break;
+  }
+});


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

further information:
Fixed worker thread blocking during large polygon ingestion

Issue:
The main thread was blocked while processing large polygons in the Ingestion_New job. This prolonged blocking prevented the service from responding to liveness checks within the expected time frame. After reaching the maximum retry attempts, the pod was automatically restarted.

Solution:
Implemented a worker thread to handle polygon polling and processing operations separately from the main thread. This ensures the main thread remains available to respond to liveness checks, preventing unwanted pod restarts.
