### PR TITLE
feat: add OpenTelemetry tracing to overseer worker(MAPCO-5642)

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,6 +1,7 @@
 import { readPackageJsonSync } from '@map-colonies/read-pkg';
 
 export const SERVICE_NAME = readPackageJsonSync().name ?? 'unknown_service';
+export const SERVICE_VERSION = readPackageJsonSync().version ?? 'unknown_version';
 export const DEFAULT_SERVER_PORT = 80;
 export const COMPLETED_PERCENTAGE = 100;
 export const JOB_SUCCESS_MESSAGE = 'Job completed successfully';

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -287,7 +287,8 @@ export interface TraceParentContext {
   tracestate?: string;
 }
 
-export type TaskProcessingTracker = {
+export type TaskProcessingTracker =
+  | {
       success: () => void;
       failure: (errorType: string) => void;
     }

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -95,7 +95,7 @@ export interface ExtendedRasterLayerMetadata extends NewRasterLayerMetadata {
   grid: Grid;
 }
 
-export type ExtendedNewRasterLayer = { metadata: ExtendedRasterLayerMetadata; additionalParams: Record<string, unknown> } & LayerData;
+export type IngestionNewExtendedJobParams = { metadata: ExtendedRasterLayerMetadata; additionalParams: Record<string, unknown> } & LayerData;
 
 export type FinalizeTaskParams = IngestionNewFinalizeTaskParams | IngestionUpdateFinalizeTaskParams | IngestionSwapUpdateFinalizeTaskParams;
 
@@ -287,8 +287,7 @@ export interface TraceParentContext {
   tracestate?: string;
 }
 
-export type TaskProcessingTracker =
-  | {
+export type TaskProcessingTracker = {
       success: () => void;
       failure: (errorType: string) => void;
     }

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -282,9 +282,21 @@ export interface SeedTaskParams {
 
 //#endregion seedingJobCreator
 
-//#region trace
+//#region telemetry
 export interface TraceParentContext {
   traceparent?: string;
   tracestate?: string;
 }
-//#endregion trace
+
+export type TaskProcessingTracker =
+  | {
+      success: () => void;
+      failure: (errorType: string) => void;
+    }
+  | undefined;
+
+export interface JobAndTaskTelemetry {
+  taskTracker: TaskProcessingTracker;
+  tracing?: TraceParentContext;
+}
+//#endregion telemetry

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -74,11 +74,9 @@ export interface TilesSeedingTaskConfig {
 //#endregion config
 
 //#region job/task interfaces
-export interface IJobHandler {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  handleJobInit: (job: IJobResponse<any, any>, task: ITaskResponse<any>) => Promise<void>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  handleJobFinalize: (job: IJobResponse<any, any>, task: ITaskResponse<any>) => Promise<void>;
+export interface IJobHandler<TInitJobParams = unknown, TInitTaskParams = unknown, TFinalizeJobParams = unknown, TFinalizeTaskParam = unknown> {
+  handleJobInit: (job: IJobResponse<TInitJobParams, TInitTaskParams>, task: ITaskResponse<TInitTaskParams>) => Promise<void>;
+  handleJobFinalize: (job: IJobResponse<TFinalizeJobParams, TFinalizeTaskParam>, task: ITaskResponse<TFinalizeTaskParam>) => Promise<void>;
 }
 
 export interface JobAndTaskResponse {

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -14,6 +14,7 @@ import {
 import { TilesMimeFormat } from '@map-colonies/types';
 import { BBox, Feature, FeatureCollection, MultiPolygon, Polygon } from 'geojson';
 import { ITileRange } from '@map-colonies/mc-utils';
+import { Span } from '@opentelemetry/api';
 import { LayerCacheType, SeedMode } from './constants';
 
 //#region config interfaces
@@ -296,7 +297,7 @@ export type TaskProcessingTracker =
   | undefined;
 
 export interface JobAndTaskTelemetry {
-  taskTracker: TaskProcessingTracker;
-  tracing?: TraceParentContext;
+  taskTracker?: TaskProcessingTracker;
+  tracingSpan?: Span;
 }
 //#endregion telemetry

--- a/src/common/tracing.ts
+++ b/src/common/tracing.ts
@@ -1,22 +1,32 @@
 import { Tracing } from '@map-colonies/telemetry';
-import { IGNORED_INCOMING_TRACE_ROUTES, IGNORED_OUTGOING_TRACE_ROUTES } from './constants';
+import { context, Span, trace } from '@opentelemetry/api';
+import { IGNORED_INCOMING_TRACE_ROUTES, IGNORED_OUTGOING_TRACE_ROUTES, SERVICE_NAME } from './constants';
 
+/* eslint-disable @typescript-eslint/naming-convention */
 const tracing = new Tracing({
   autoInstrumentationsConfigMap: {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     '@opentelemetry/instrumentation-http': {
+      requireParentforOutgoingSpans: true,
       ignoreIncomingRequestHook: (request): boolean =>
         IGNORED_INCOMING_TRACE_ROUTES.some((route) => request.url !== undefined && route.test(request.url)),
       ignoreOutgoingRequestHook: (request): boolean =>
         IGNORED_OUTGOING_TRACE_ROUTES.some((route) => typeof request.path === 'string' && route.test(request.path)),
     },
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     '@opentelemetry/instrumentation-fs': {
       requireParentSpan: true,
     },
+    '@opentelemetry/instrumentation-express': {
+      enabled: false,
+    },
   },
 });
+/* eslint-enable @typescript-eslint/naming-convention */
 
 tracing.start();
 
-export { tracing };
+const createChildSpan = (name: string, parentSpan: Span | undefined): Span => {
+  const ctx = parentSpan ? trace.setSpan(context.active(), parentSpan) : context.active();
+  return trace.getTracer(SERVICE_NAME).startSpan(name, undefined, ctx);
+};
+
+export { tracing, createChildSpan };

--- a/src/common/tracing.ts
+++ b/src/common/tracing.ts
@@ -6,20 +6,21 @@ import { IGNORED_INCOMING_TRACE_ROUTES, IGNORED_OUTGOING_TRACE_ROUTES, SERVICE_N
 const tracing = new Tracing({
   autoInstrumentationsConfigMap: {
     '@opentelemetry/instrumentation-http': {
-      requireParentforOutgoingSpans: true,
+      requireParentforOutgoingSpans: true, //  Ensures HTTP calls must have a parent span to be traced
       ignoreIncomingRequestHook: (request): boolean =>
         IGNORED_INCOMING_TRACE_ROUTES.some((route) => request.url !== undefined && route.test(request.url)),
       ignoreOutgoingRequestHook: (request): boolean =>
         IGNORED_OUTGOING_TRACE_ROUTES.some((route) => typeof request.path === 'string' && route.test(request.path)),
     },
     '@opentelemetry/instrumentation-fs': {
-      requireParentSpan: true,
+      requireParentSpan: true, // Ensures FS operations must have a parent span to be traced
     },
     '@opentelemetry/instrumentation-express': {
-      enabled: false,
+      enabled: false, // Express instrumentation is disabled since this is a worker service without HTTP routes
     },
   },
 });
+// This configuration ensures we only trace operations that are part of actual worker tasks, reducing noise from standalone operations.
 /* eslint-enable @typescript-eslint/naming-convention */
 
 tracing.start();

--- a/src/containerConfig.ts
+++ b/src/containerConfig.ts
@@ -8,7 +8,7 @@ import { Registry } from 'prom-client';
 import { instanceCachingFactory, instancePerContainerCachingFactory } from 'tsyringe';
 import { DependencyContainer } from 'tsyringe/dist/typings/types';
 import jsLogger, { Logger, LoggerOptions } from '@map-colonies/js-logger';
-import { INJECTION_VALUES, SERVICES, SERVICE_NAME } from './common/constants';
+import { INJECTION_VALUES, SERVICES, SERVICE_NAME, SERVICE_VERSION } from './common/constants';
 import { tracing } from './common/tracing';
 import { InjectionObject, registerDependencies } from './common/dependencyRegistration';
 import { NewJobHandler } from './job/models/newJobHandler';
@@ -48,7 +48,7 @@ export const registerExternalValues = (options?: RegisterOptions): DependencyCon
   const logger = jsLogger({ ...loggerConfig, prettyPrint: loggerConfig.prettyPrint, mixin: getOtelMixin(), pinoCaller: loggerConfig.pinoCaller });
 
   const metricsRegistry = new Registry();
-  const tracer = trace.getTracer(SERVICE_NAME);
+  const tracer = trace.getTracer(SERVICE_NAME, SERVICE_VERSION);
 
   const ingestionConfig = config.get<IngestionPollingJobs>('jobManagement.ingestion.pollingJobs');
 

--- a/src/httpClients/geoserverClient.ts
+++ b/src/httpClients/geoserverClient.ts
@@ -1,11 +1,11 @@
 import { IConfig } from 'config';
 import { Logger } from '@map-colonies/js-logger';
 import { HttpClient, IHttpRetryConfig } from '@map-colonies/mc-utils';
+import { context, SpanStatusCode, trace, Tracer } from '@opentelemetry/api';
 import { inject, injectable } from 'tsyringe';
 import { SERVICES } from '../common/constants';
 import { InsertGeoserverRequest, LayerNameFormats } from '../common/interfaces';
 import { PublishLayerError } from '../common/errors';
-import { context, SpanStatusCode, trace, Tracer } from '@opentelemetry/api';
 
 @injectable()
 export class GeoserverClient extends HttpClient {
@@ -40,6 +40,7 @@ export class GeoserverClient extends HttpClient {
         };
 
         await this.post(url, publishReq);
+        activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Layer published successfully to geoserver' });
       } catch (err) {
         if (err instanceof Error) {
           activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: err.message });

--- a/src/httpClients/geoserverClient.ts
+++ b/src/httpClients/geoserverClient.ts
@@ -5,12 +5,17 @@ import { inject, injectable } from 'tsyringe';
 import { SERVICES } from '../common/constants';
 import { InsertGeoserverRequest, LayerNameFormats } from '../common/interfaces';
 import { PublishLayerError } from '../common/errors';
+import { context, SpanStatusCode, trace, Tracer } from '@opentelemetry/api';
 
 @injectable()
 export class GeoserverClient extends HttpClient {
   private readonly workspace: string;
   private readonly dataStore: string;
-  public constructor(@inject(SERVICES.CONFIG) private readonly config: IConfig, @inject(SERVICES.LOGGER) protected readonly logger: Logger) {
+  public constructor(
+    @inject(SERVICES.CONFIG) private readonly config: IConfig,
+    @inject(SERVICES.LOGGER) protected readonly logger: Logger,
+    @inject(SERVICES.TRACER) private readonly tracer: Tracer
+  ) {
     const serviceName = 'GeoserverApi';
     const baseUrl = config.get<string>('servicesUrl.geoserverApi');
     const httpRetryConfig = config.get<IHttpRetryConfig>('httpRetry');
@@ -21,19 +26,29 @@ export class GeoserverClient extends HttpClient {
   }
 
   public async publish(layerNames: LayerNameFormats): Promise<void> {
-    const { nativeName, layerName } = layerNames;
-    try {
-      const url = `/featureTypes/${this.workspace}/${this.dataStore}`;
-      const publishReq: InsertGeoserverRequest = {
-        nativeName,
-        name: layerName,
-      };
+    await context.with(trace.setSpan(context.active(), this.tracer.startSpan(`${GeoserverClient.name}.${this.publish.name}`)), async () => {
+      const activeSpan = trace.getActiveSpan();
 
-      await this.post(url, publishReq);
-    } catch (err) {
-      if (err instanceof Error) {
-        throw new PublishLayerError(this.targetService, layerName, err);
+      const { nativeName, layerName } = layerNames;
+      activeSpan?.setAttributes({ nativeName, layerName });
+
+      try {
+        const url = `/featureTypes/${this.workspace}/${this.dataStore}`;
+        const publishReq: InsertGeoserverRequest = {
+          nativeName,
+          name: layerName,
+        };
+
+        await this.post(url, publishReq);
+      } catch (err) {
+        if (err instanceof Error) {
+          activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+          activeSpan?.recordException(err);
+          throw new PublishLayerError(this.targetService, layerName, err);
+        }
+      } finally {
+        activeSpan?.end();
       }
-    }
+    });
   }
 }

--- a/src/httpClients/mapproxyClient.ts
+++ b/src/httpClients/mapproxyClient.ts
@@ -63,7 +63,7 @@ export class MapproxyApiClient extends HttpClient {
   }
 
   public async update(layerName: string, tilesPath: string, format: TileOutputFormat): Promise<void> {
-    await context.with(trace.setSpan(context.active(), this.tracer.startSpan(`${MapproxyApiClient.name}.${this.publish.name}`)), async () => {
+    await context.with(trace.setSpan(context.active(), this.tracer.startSpan(`${MapproxyApiClient.name}.${this.update.name}`)), async () => {
       const activeSpan = trace.getActiveSpan();
       const cacheType = this.layerCacheType;
 

--- a/src/job/models/jobHandler.ts
+++ b/src/job/models/jobHandler.ts
@@ -1,5 +1,6 @@
 import z, { ZodError } from 'zod';
 import { IJobResponse, ITaskResponse, OperationStatus, TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
+import { SpanStatusCode } from '@opentelemetry/api';
 import { Logger } from '@map-colonies/js-logger';
 import { layerNameSchema } from '../../utils/zod/schemas/jobParametersSchema';
 import { FinalizeTaskParams, LayerNameFormats, JobAndTaskTelemetry } from '../../common/interfaces';
@@ -45,16 +46,40 @@ export class JobHandler {
     return result.data as z.infer<T>;
   }
 
-  protected async completeTaskAndJob(job: IJobResponse<unknown, unknown>, task: ITaskResponse<unknown>): Promise<void> {
+  protected async completeInitTask(job: IJobResponse<unknown, unknown>, task: ITaskResponse<unknown>, telemetry: JobAndTaskTelemetry): Promise<void> {
+    const { taskTracker, tracingSpan } = telemetry;
     const logger = this.logger.child({ jobId: job.id, taskId: task.id, jobType: job.type, taskType: task.type });
-    logger.info({ msg: 'acknowledging task' });
+
+    logger.info({ msg: 'Acking task' });
     await this.queueClient.ack(job.id, task.id);
+
+    const successMsg = `${task.type} task  completed successfully`;
+    taskTracker?.success();
+    tracingSpan?.setStatus({ code: SpanStatusCode.OK, message: successMsg });
+    logger.info({ msg: successMsg });
+  }
+
+  protected async completeTaskAndJob(
+    job: IJobResponse<unknown, unknown>,
+    task: ITaskResponse<unknown>,
+    telemetry: JobAndTaskTelemetry
+  ): Promise<void> {
+    const { taskTracker, tracingSpan } = telemetry;
+    const logger = this.logger.child({ jobId: job.id, taskId: task.id, jobType: job.type, taskType: task.type });
+
+    logger.info({ msg: 'acknowledging task' });
+    tracingSpan?.addEvent('acknowledging.task');
+    await this.queueClient.ack(job.id, task.id);
+
     logger.info({ msg: 'updating job status to completed' });
     await this.queueClient.jobManagerClient.updateJob(job.id, {
       status: OperationStatus.COMPLETED,
       percentage: COMPLETED_PERCENTAGE,
       reason: JOB_SUCCESS_MESSAGE,
     });
+
+    taskTracker?.success();
+    tracingSpan?.setStatus({ code: SpanStatusCode.OK, message: JOB_SUCCESS_MESSAGE });
   }
 
   protected async handleError(
@@ -63,16 +88,18 @@ export class JobHandler {
     task: ITaskResponse<unknown>,
     telemetry: JobAndTaskTelemetry
   ): Promise<void> {
-    const { taskTracker } = telemetry;
+    const { taskTracker, tracingSpan } = telemetry;
     const logger = this.logger.child({ jobId: job.id, taskId: task.id, jobType: job.type, taskType: task.type });
     const errName = error instanceof Error ? error.name : 'unknown';
     const msg = `Failed to handle ${job.type} job with ${task.type} task`;
     const reason = error instanceof Error ? error.message : String(error);
     const isRecoverable = !(error instanceof ZodError);
 
+    await this.queueClient.reject(job.id, task.id, isRecoverable, reason);
     logger.error({ msg, reason, error });
     taskTracker?.failure(errName);
-    await this.queueClient.reject(job.id, task.id, isRecoverable, reason);
+    tracingSpan?.setStatus({ code: SpanStatusCode.ERROR, message: reason });
+    tracingSpan?.recordException(error instanceof Error ? error : new Error(reason));
 
     if (!isRecoverable) {
       await this.queueClient.jobManagerClient.updateJob(job.id, { status: OperationStatus.FAILED, reason: error.message });

--- a/src/job/models/jobHandler.ts
+++ b/src/job/models/jobHandler.ts
@@ -53,7 +53,7 @@ export class JobHandler {
     logger.info({ msg: 'Acking task' });
     await this.queueClient.ack(job.id, task.id);
 
-    const successMsg = `${task.type} task  completed successfully`;
+    const successMsg = `${task.type} task completed successfully`;
     taskTracker?.success();
     tracingSpan?.setStatus({ code: SpanStatusCode.OK, message: successMsg });
     logger.info({ msg: successMsg });

--- a/src/job/models/newJobHandler.ts
+++ b/src/job/models/newJobHandler.ts
@@ -7,7 +7,7 @@ import { TilesMimeFormat, lookup as mimeLookup } from '@map-colonies/types';
 import { IngestionNewFinalizeTaskParams, IngestionNewJobParams, NewRasterLayerMetadata } from '@map-colonies/mc-model-types';
 import { TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
 import { newAdditionalParamsSchema } from '../../utils/zod/schemas/jobParametersSchema';
-import { Grid, IJobHandler, MergeTilesTaskParams, ExtendedRasterLayerMetadata, ExtendedNewRasterLayer } from '../../common/interfaces';
+import { Grid, IJobHandler, MergeTilesTaskParams, ExtendedRasterLayerMetadata, IngestionNewExtendedJobParams } from '../../common/interfaces';
 import { TaskMetrics } from '../../utils/metrics/taskMetrics';
 import { SERVICES } from '../../common/constants';
 import { getTileOutputFormat } from '../../utils/imageFormatUtil';
@@ -21,7 +21,7 @@ import { JobHandler } from './jobHandler';
 /* eslint-disable @typescript-eslint/brace-style */
 export class NewJobHandler
   extends JobHandler
-  implements IJobHandler<IngestionNewJobParams, unknown, ExtendedNewRasterLayer, IngestionNewFinalizeTaskParams>
+  implements IJobHandler<IngestionNewJobParams, unknown, IngestionNewExtendedJobParams, IngestionNewFinalizeTaskParams>
 {
   /* eslint-enable @typescript-eslint/brace-style */
   public constructor(
@@ -86,7 +86,7 @@ export class NewJobHandler
   }
 
   public async handleJobFinalize(
-    job: IJobResponse<ExtendedNewRasterLayer, unknown>,
+    job: IJobResponse<IngestionNewExtendedJobParams, unknown>,
     task: ITaskResponse<IngestionNewFinalizeTaskParams>
   ): Promise<void> {
     await context.with(trace.setSpan(context.active(), this.tracer.startSpan(`${NewJobHandler.name}.${this.handleJobFinalize.name}`)), async () => {

--- a/src/job/models/newJobHandler.ts
+++ b/src/job/models/newJobHandler.ts
@@ -18,7 +18,12 @@ import { CatalogClient } from '../../httpClients/catalogClient';
 import { JobHandler } from './jobHandler';
 
 @injectable()
-export class NewJobHandler extends JobHandler implements IJobHandler {
+/* eslint-disable @typescript-eslint/brace-style */
+export class NewJobHandler
+  extends JobHandler
+  implements IJobHandler<IngestionNewJobParams, unknown, ExtendedNewRasterLayer, IngestionNewFinalizeTaskParams>
+{
+  /* eslint-enable @typescript-eslint/brace-style */
   public constructor(
     @inject(SERVICES.LOGGER) logger: Logger,
     @inject(SERVICES.TRACER) public readonly tracer: Tracer,
@@ -62,7 +67,6 @@ export class NewJobHandler extends JobHandler implements IJobHandler {
         logger.info({ msg: 'building tasks' });
         const mergeTasks = this.taskBuilder.buildTasks(taskBuildParams);
 
-        logger.info({ msg: 'pushing tasks' });
         await this.taskBuilder.pushTasks(job.id, job.type, mergeTasks);
 
         logger.info({ msg: 'Updating job with new metadata', ...metadata, extendedLayerMetadata });
@@ -99,7 +103,7 @@ export class NewJobHandler extends JobHandler implements IJobHandler {
         const { insertedToMapproxy, insertedToGeoServer, insertedToCatalog } = finalizeTaskParams;
         const { layerRelativePath, tileOutputFormat } = job.parameters.metadata;
         const layerNameFormats = this.validateAndGenerateLayerNameFormats(job);
-        activeSpan?.addEvent('validateAndGenerateLayerNameFormats.success', { ...layerNameFormats });
+        activeSpan?.addEvent('layerNameFormats.valid', { ...layerNameFormats });
 
         if (!insertedToMapproxy) {
           const layerName = layerNameFormats.layerName;
@@ -136,7 +140,6 @@ export class NewJobHandler extends JobHandler implements IJobHandler {
     });
   }
 
-  // eslint-disable-next-line @typescript-eslint/member-ordering
   private readonly mapToExtendedNewLayerMetadata = (metadata: NewRasterLayerMetadata): ExtendedRasterLayerMetadata => {
     const catalogId = randomUUID();
     const displayPath = randomUUID();

--- a/src/job/models/updateJobHandler.ts
+++ b/src/job/models/updateJobHandler.ts
@@ -1,6 +1,7 @@
 import { inject, injectable } from 'tsyringe';
 import { Logger } from '@map-colonies/js-logger';
 import { TaskHandler as QueueClient, IJobResponse, ITaskResponse } from '@map-colonies/mc-priority-queue';
+import { context, trace, Tracer } from '@opentelemetry/api';
 import { IngestionUpdateFinalizeTaskParams, IngestionUpdateJobParams } from '@map-colonies/mc-model-types';
 import { CatalogClient } from '../../httpClients/catalogClient';
 import { Grid, IConfig, IJobHandler, MergeTilesTaskParams } from '../../common/interfaces';
@@ -15,6 +16,7 @@ import { SeedingJobCreator } from './seedingJobCreator';
 export class UpdateJobHandler extends JobHandler implements IJobHandler {
   public constructor(
     @inject(SERVICES.LOGGER) logger: Logger,
+    @inject(SERVICES.TRACER) public readonly tracer: Tracer,
     @inject(SERVICES.CONFIG) private readonly config: IConfig,
     @inject(TileMergeTaskManager) private readonly taskBuilder: TileMergeTaskManager,
     @inject(SERVICES.QUEUE_CLIENT) protected queueClient: QueueClient,
@@ -26,38 +28,46 @@ export class UpdateJobHandler extends JobHandler implements IJobHandler {
   }
 
   public async handleJobInit(job: IJobResponse<IngestionUpdateJobParams, unknown>, task: ITaskResponse<unknown>): Promise<void> {
-    const logger = this.logger.child({ jobId: job.id, taskId: task.id, jobType: job.type });
-    const taskProcessTracking = this.taskMetrics.trackTaskProcessing(job.type, task.type);
+    await context.with(trace.setSpan(context.active(), this.tracer.startSpan(`${UpdateJobHandler.name}.${this.handleJobInit.name}`)), async () => {
+      const activeSpan = trace.getActiveSpan();
 
-    try {
-      logger.info({ msg: `handling ${job.type} job with "init" task` });
-      const { inputFiles, partsData, additionalParams } = job.parameters;
+      const logger = this.logger.child({ jobId: job.id, taskId: task.id, jobType: job.type });
+      const taskProcessTracking = this.taskMetrics.trackTaskProcessing(job.type, task.type);
 
-      const validAdditionalParams = this.validateAdditionalParams(additionalParams, updateAdditionalParamsSchema);
+      try {
+        logger.info({ msg: `handling ${job.type} job with "init" task` });
+        const { inputFiles, partsData, additionalParams, metadata } = job.parameters;
 
-      const taskBuildParams: MergeTilesTaskParams = {
-        inputFiles,
-        taskMetadata: {
-          layerRelativePath: `${job.internalId}/${validAdditionalParams.displayPath}`,
-          tileOutputFormat: validAdditionalParams.tileOutputFormat,
-          isNewTarget: false,
-          grid: Grid.TWO_ON_ONE,
-        },
-        partsData,
-      };
+        activeSpan?.setAttributes({ ...metadata });
 
-      logger.info({ msg: 'building tasks' });
-      const mergeTasks = this.taskBuilder.buildTasks(taskBuildParams);
+        const validAdditionalParams = this.validateAdditionalParams(additionalParams, updateAdditionalParamsSchema);
 
-      logger.info({ msg: 'pushing tasks' });
-      await this.taskBuilder.pushTasks(job.id, job.type, mergeTasks);
+        activeSpan?.addEvent('validateAdditionalParams.success');
 
-      logger.info({ msg: 'Acking task' });
-      await this.queueClient.ack(job.id, task.id);
-      taskProcessTracking?.success();
-    } catch (err) {
-      await this.handleError(err, job, task, { taskTracker: taskProcessTracking });
-    }
+        const taskBuildParams: MergeTilesTaskParams = {
+          inputFiles,
+          taskMetadata: {
+            layerRelativePath: `${job.internalId}/${validAdditionalParams.displayPath}`,
+            tileOutputFormat: validAdditionalParams.tileOutputFormat,
+            isNewTarget: false,
+            grid: Grid.TWO_ON_ONE,
+          },
+          partsData,
+        };
+
+        logger.info({ msg: 'building tasks' });
+        const mergeTasks = this.taskBuilder.buildTasks(taskBuildParams);
+
+        logger.info({ msg: 'pushing tasks' });
+        await this.taskBuilder.pushTasks(job.id, job.type, mergeTasks);
+
+        await this.completeInitTask(job, task, { taskTracker: taskProcessTracking, tracingSpan: activeSpan });
+      } catch (err) {
+        await this.handleError(err, job, task, { taskTracker: taskProcessTracking, tracingSpan: activeSpan });
+      } finally {
+        activeSpan?.end();
+      }
+    });
   }
 
   public async handleJobFinalize(
@@ -81,7 +91,7 @@ export class UpdateJobHandler extends JobHandler implements IJobHandler {
 
       if (this.isAllStepsCompleted(finalizeTaskParams)) {
         logger.info({ msg: 'All finalize steps completed successfully', ...finalizeTaskParams });
-        await this.completeTaskAndJob(job, task);
+        await this.completeTaskAndJob(job, task, {});
         taskProcessTracking?.success();
         await this.seedingJobCreator.create({ mode: SeedMode.SEED, layerName, ingestionJob: job });
       }

--- a/src/task/models/tileMergeTaskManager.ts
+++ b/src/task/models/tileMergeTaskManager.ts
@@ -118,7 +118,8 @@ export class TileMergeTaskManager {
         }
 
         if (taskBatch.length === this.taskBatchSize) {
-          logger.info({ msg: 'Pushing task batch to queue', batchLength: taskBatch.length });
+          logger.info({ msg: 'Pushing leftovers task batch to queue', batchLength: taskBatch.length });
+          activeSpan?.addEvent('enqueueTasks.leftovers', { currentTaskBatchSize: taskBatch.length });
           await this.enqueueTasks(jobId, taskBatch);
         }
         logger.info({ msg: `Successfully pushed all tasks to queue` });

--- a/src/task/models/tileMergeTaskManager.ts
+++ b/src/task/models/tileMergeTaskManager.ts
@@ -104,7 +104,6 @@ export class TileMergeTaskManager {
 
       try {
         for await (const task of tasks) {
-          // const span = createChildSpan(`${TileMergeTaskManager.name}.${this.pushTasks.name}`, task.span);
           const taskBody: ICreateTaskBody<MergeTaskParameters> = { description: 'merge tiles task', parameters: task, type: this.taskType };
           taskBatch.push(taskBody);
           this.taskMetrics.trackTasksEnqueue(jobType, this.taskType, task.batches.length);
@@ -124,6 +123,10 @@ export class TileMergeTaskManager {
         }
         logger.info({ msg: `Successfully pushed all tasks to queue` });
       } catch (error) {
+        if (error instanceof Error) {
+          activeSpan?.recordException(error);
+          activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+        }
         logger.error({ msg: 'Failed to push tasks to queue', error });
         throw error;
       } finally {

--- a/src/task/models/tileMergeTaskManager.ts
+++ b/src/task/models/tileMergeTaskManager.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import { Logger } from '@map-colonies/js-logger';
+import { context, Span, SpanStatusCode, trace, Tracer } from '@opentelemetry/api';
 import { InputFiles, PolygonPart } from '@map-colonies/mc-model-types';
 import { ICreateTaskBody, TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
 import { degreesPerPixelToZoomLevel, tileBatchGenerator, TileRanger } from '@map-colonies/mc-utils';
@@ -22,6 +23,7 @@ import {
 } from '../../common/interfaces';
 import { fileExtensionExtractor } from '../../utils/fileutils';
 import { TaskMetrics } from '../../utils/metrics/taskMetrics';
+import { createChildSpan } from '../../common/tracing';
 
 @injectable()
 export class TileMergeTaskManager {
@@ -31,6 +33,7 @@ export class TileMergeTaskManager {
   private readonly taskType: string;
   public constructor(
     @inject(SERVICES.LOGGER) private readonly logger: Logger,
+    @inject(SERVICES.TRACER) private readonly tracer: Tracer,
     @inject(SERVICES.CONFIG) private readonly config: IConfig,
     @inject(SERVICES.TILE_RANGER) private readonly tileRanger: TileRanger,
     @inject(SERVICES.QUEUE_CLIENT) private readonly queueClient: QueueClient,
@@ -43,51 +46,81 @@ export class TileMergeTaskManager {
   }
 
   public buildTasks(taskBuildParams: MergeTilesTaskParams): AsyncGenerator<MergeTaskParameters, void, void> {
-    const logger = this.logger.child({ taskType: this.taskType });
+    return context.with(trace.setSpan(context.active(), this.tracer.startSpan(`${TileMergeTaskManager.name}.${this.buildTasks.name}`)), () => {
+      const activeSpan = trace.getActiveSpan();
+      activeSpan?.setAttributes({
+        taskType: this.taskType,
+        partsLength: taskBuildParams.partsData.length,
+        ...taskBuildParams.taskMetadata,
+        ...taskBuildParams.inputFiles,
+      });
 
-    logger.debug({ msg: `Building tasks for ${this.taskType} task` });
+      const logger = this.logger.child({ taskType: this.taskType });
 
-    try {
-      const mergeParams = this.prepareMergeParameters(taskBuildParams);
-      const tasks = this.createZoomLevelTasks(mergeParams);
-      logger.debug({ msg: `Successfully built tasks for ${this.taskType} task` });
-      return tasks;
-    } catch (error) {
-      const errorMsg = (error as Error).message;
-      logger.error({ msg: `Failed to build tasks for ${this.taskType} task: ${errorMsg}`, error });
-      throw error;
-    }
+      logger.debug({ msg: `Building tasks for ${this.taskType} task` });
+
+      try {
+        const mergeParams = this.prepareMergeParameters(taskBuildParams);
+        activeSpan?.addEvent('Merge parameters prepared', {
+          ...mergeParams.zoomDefinitions,
+          ...mergeParams.tilesSource,
+        });
+
+        const tasks = this.createZoomLevelTasks(mergeParams, activeSpan);
+
+        logger.debug({ msg: `Successfully built tasks for ${this.taskType} task` });
+        return tasks;
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        const errorMsg = error.message;
+        logger.error({ msg: `Failed to build tasks for ${this.taskType} task: ${errorMsg}`, error });
+        activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: errorMsg });
+        activeSpan?.recordException(error);
+        throw error;
+      } finally {
+        activeSpan?.end();
+      }
+    });
   }
 
   public async pushTasks(jobId: string, jobType: string, tasks: AsyncGenerator<MergeTaskParameters, void, void>): Promise<void> {
-    this.taskMetrics.resetTrackTasksEnqueue(jobType, this.taskType);
+    await context.with(trace.setSpan(context.active(), this.tracer.startSpan(`${TileMergeTaskManager.name}.${this.pushTasks.name}`)), async () => {
+      const activeSpan = trace.getActiveSpan();
 
-    const logger = this.logger.child({ jobId, jobType, taskType: this.taskType });
-    let taskBatch: ICreateTaskBody<MergeTaskParameters>[] = [];
+      activeSpan?.setAttributes({ taskBatchSize: this.taskBatchSize });
+      this.taskMetrics.resetTrackTasksEnqueue(jobType, this.taskType);
 
-    try {
-      for await (const task of tasks) {
-        const taskBody: ICreateTaskBody<MergeTaskParameters> = { description: 'merge tiles task', parameters: task, type: this.taskType };
-        taskBatch.push(taskBody);
-        this.taskMetrics.trackTasksEnqueue(jobType, this.taskType, task.batches.length);
+      const logger = this.logger.child({ jobId, jobType, taskType: this.taskType });
+      let taskBatch: ICreateTaskBody<MergeTaskParameters>[] = [];
 
-        if (taskBatch.length === this.taskBatchSize) {
-          logger.debug({ msg: 'Pushing task batch to queue', batchLength: taskBatch.length, taskBatch });
-          await this.enqueueTasks(jobId, taskBatch);
-          taskBatch = [];
+      try {
+        for await (const task of tasks) {
+          // const span = createChildSpan(`${TileMergeTaskManager.name}.${this.pushTasks.name}`, task.span);
+          const taskBody: ICreateTaskBody<MergeTaskParameters> = { description: 'merge tiles task', parameters: task, type: this.taskType };
+          taskBatch.push(taskBody);
+          this.taskMetrics.trackTasksEnqueue(jobType, this.taskType, task.batches.length);
+
+          if (taskBatch.length === this.taskBatchSize) {
+            logger.debug({ msg: 'Pushing task batch to queue', batchLength: taskBatch.length, taskBatch });
+            activeSpan?.addEvent('enqueueTasks', { currentTaskBatchSize: taskBatch.length });
+            await this.enqueueTasks(jobId, taskBatch);
+            taskBatch = [];
+          }
         }
-      }
 
-      if (taskBatch.length > 0) {
-        logger.debug({ msg: 'Pushing last task batch to queue', batchLength: taskBatch.length, taskBatch });
-        await this.enqueueTasks(jobId, taskBatch);
+        if (taskBatch.length > 0) {
+          logger.debug({ msg: 'Pushing last tasks batch to queue', batchLength: taskBatch.length, taskBatch });
+          activeSpan?.addEvent('enqueueTasks.leftovers', { currentTaskBatchSize: taskBatch.length });
+          await this.enqueueTasks(jobId, taskBatch);
+        }
+        logger.info({ msg: `Successfully pushed all tasks to queue` });
+      } catch (error) {
+        logger.error({ msg: 'Failed to push tasks to queue', error });
+        throw error;
+      } finally {
+        activeSpan?.end();
       }
-    } catch (error) {
-      logger.error({ msg: 'Failed to push tasks to queue', error });
-      throw error;
-    }
-
-    logger.info({ msg: `Successfully pushed all tasks to queue` });
+    });
   }
 
   private async enqueueTasks(jobId: string, tasks: ICreateTaskBody<MergeTaskParameters>[]): Promise<void> {
@@ -183,11 +216,15 @@ export class TileMergeTaskManager {
     return featurePolygon;
   }
 
-  private async *createZoomLevelTasks(params: MergeParameters): AsyncGenerator<MergeTaskParameters, void, void> {
+  private async *createZoomLevelTasks(params: MergeParameters, parentSpan: Span | undefined): AsyncGenerator<MergeTaskParameters, void, void> {
+    const span = createChildSpan(`${TileMergeTaskManager.name}.${this.createZoomLevelTasks.name}`, parentSpan);
+
     const { ppCollection, taskMetadata, zoomDefinitions, tilesSource } = params;
     const { maxZoom, partsZoomLevelMatch } = zoomDefinitions;
 
     let unifiedPart: UnifiedPart | null = partsZoomLevelMatch ? this.unifyParts(ppCollection, tilesSource) : null;
+
+    span.setAttributes({ partsZoomLevelMatch, maxZoom, ppCollectionLength: ppCollection.features.length });
 
     for (let zoom = maxZoom; zoom >= 0; zoom--) {
       if (!partsZoomLevelMatch) {
@@ -195,9 +232,9 @@ export class TileMergeTaskManager {
         const collection = featureCollection(filteredFeatures);
         unifiedPart = this.unifyParts(collection, tilesSource);
       }
-
-      yield* this.createTasksForPart(unifiedPart!, zoom, taskMetadata);
+      yield* this.createTasksForPart(unifiedPart!, zoom, taskMetadata, span);
     }
+    span.end();
   }
 
   private unifyParts(featureCollection: PPFeatureCollection, tilesSource: TilesSource): UnifiedPart {
@@ -230,8 +267,11 @@ export class TileMergeTaskManager {
   private async *createTasksForPart(
     part: UnifiedPart,
     zoom: number,
-    tilesMetadata: MergeTilesMetadata
+    tilesMetadata: MergeTilesMetadata,
+    parentSpan?: Span | undefined
   ): AsyncGenerator<MergeTaskParameters, void, void> {
+    const span = createChildSpan(`${TileMergeTaskManager.name}.${this.createTasksForPart.name}.zoom.${zoom}`, parentSpan);
+    span.setAttributes({ part: JSON.stringify(part), zoom, maxTileBatchSize: this.tileBatchSize });
     const { layerRelativePath, grid, isNewTarget, tileOutputFormat } = tilesMetadata;
     const logger = this.logger.child({ zoomLevel: zoom, isNewTarget, layerRelativePath, tileOutputFormat, grid });
 
@@ -242,6 +282,7 @@ export class TileMergeTaskManager {
 
     for await (const batch of batches) {
       logger.debug({ msg: 'Yielding batch task', batchSize: batch.length });
+      span.addEvent('Yielding batch task', { batchSize: batch.length, batch: JSON.stringify(batch) });
       yield {
         targetFormat: tileOutputFormat,
         isNewTarget: isNewTarget,
@@ -249,6 +290,7 @@ export class TileMergeTaskManager {
         sources,
       };
     }
+    span.end();
   }
 
   private createPartSources(part: UnifiedPart, grid: Grid, destPath: string): MergeSources[] {

--- a/src/utils/metrics/taskMetrics.ts
+++ b/src/utils/metrics/taskMetrics.ts
@@ -2,7 +2,7 @@ import { inject, singleton } from 'tsyringe';
 import { Counter, Gauge, Histogram, Registry } from 'prom-client';
 import { OperationStatus } from '@map-colonies/mc-priority-queue';
 import { SERVICES } from '../../common/constants';
-import { IConfig } from '../../common/interfaces';
+import { IConfig, TaskProcessingTracker } from '../../common/interfaces';
 
 @singleton()
 export class TaskMetrics {
@@ -64,7 +64,7 @@ export class TaskMetrics {
     }
   }
 
-  public trackTaskProcessing(jobType: string, taskType: string): { success: () => void; failure: (errorType: string) => void } | void {
+  public trackTaskProcessing(jobType: string, taskType: string): TaskProcessingTracker | undefined {
     const timer = this.tasksProcessingDuration?.startTimer({
       jobType,
       taskType,

--- a/src/utils/metrics/taskMetrics.ts
+++ b/src/utils/metrics/taskMetrics.ts
@@ -64,7 +64,7 @@ export class TaskMetrics {
     }
   }
 
-  public trackTaskProcessing(jobType: string, taskType: string): TaskProcessingTracker | undefined {
+  public trackTaskProcessing(jobType: string, taskType: string): TaskProcessingTracker {
     const timer = this.tasksProcessingDuration?.startTimer({
       jobType,
       taskType,

--- a/src/utils/tracing/overseerTracer.ts
+++ b/src/utils/tracing/overseerTracer.ts
@@ -1,1 +1,0 @@
-export class OverseerTracer {}

--- a/src/utils/tracing/overseerTracer.ts
+++ b/src/utils/tracing/overseerTracer.ts
@@ -1,0 +1,1 @@
+export class OverseerTracer {}

--- a/tests/configurations/unit/jest.config.js
+++ b/tests/configurations/unit/jest.config.js
@@ -30,7 +30,7 @@ module.exports = {
       branches: 80,
       functions: 80,
       lines: 80,
-      statements: -12,
+      statements: -15,
     },
   },
 };

--- a/tests/unit/httpClients/catalogClientSetup.ts
+++ b/tests/unit/httpClients/catalogClientSetup.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Link } from '@map-colonies/mc-model-types';
 import jsLogger from '@map-colonies/js-logger';
+import { trace } from '@opentelemetry/api';
 import { faker } from '@faker-js/faker';
 import { ILinkBuilderData, LinkBuilder } from '../../../src/utils/linkBuilder';
 import { configMock, registerDefaultConfig } from '../mocks/configMock';
@@ -34,7 +35,9 @@ export function setupCatalogClientTest(): CatalogClientTestContext {
   const polygonPartsManagerClientMock = {
     getAggregatedLayerMetadata: jest.fn(),
   } as unknown as jest.Mocked<PolygonPartsMangerClient>;
-  const catalogClient = new CatalogClient(configMock, jsLogger({ enabled: false }), jobTypes, linkBuilder, polygonPartsManagerClientMock);
+
+  const tracerMock = trace.getTracer('test');
+  const catalogClient = new CatalogClient(configMock, jsLogger({ enabled: false }), tracerMock, jobTypes, linkBuilder, polygonPartsManagerClientMock);
 
   return {
     createLinksMock,

--- a/tests/unit/httpClients/geoserverClient.spec.ts
+++ b/tests/unit/httpClients/geoserverClient.spec.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import jsLogger from '@map-colonies/js-logger';
+import { trace } from '@opentelemetry/api';
 import { GeoserverClient } from '../../../src/httpClients/geoserverClient';
 import { configMock, registerDefaultConfig } from '../mocks/configMock';
 import { PublishLayerError } from '../../../src/common/errors';
@@ -9,7 +10,8 @@ describe('GeoserverClient', () => {
   let geoServerClient: GeoserverClient;
   beforeEach(() => {
     registerDefaultConfig();
-    geoServerClient = new GeoserverClient(configMock, jsLogger({ enabled: false }));
+    const tracerMock = trace.getTracer('test');
+    geoServerClient = new GeoserverClient(configMock, jsLogger({ enabled: false }), tracerMock);
   });
 
   afterEach(() => {

--- a/tests/unit/httpClients/mapproxyClient.spec.ts
+++ b/tests/unit/httpClients/mapproxyClient.spec.ts
@@ -1,5 +1,6 @@
 import nock from 'nock';
 import jsLogger from '@map-colonies/js-logger';
+import { trace, Tracer } from '@opentelemetry/api';
 import { TileOutputFormat } from '@map-colonies/mc-model-types';
 import { MapproxyApiClient } from '../../../src/httpClients/mapproxyClient';
 import { configMock, init as InitConfig, setValue } from '../mocks/configMock';
@@ -14,8 +15,10 @@ import { LayerCacheType } from '../../../src/common/constants';
 
 describe('mapproxyClient', () => {
   let mapproxyApiClient: MapproxyApiClient;
+  let tracerMock: Tracer;
 
   beforeEach(() => {
+    tracerMock = trace.getTracer('test');
     InitConfig();
   });
 
@@ -28,7 +31,7 @@ describe('mapproxyClient', () => {
     it('should publish a layer to mapproxy', async () => {
       setValue('tilesStorageProvider', 'FS');
 
-      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }));
+      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }), tracerMock);
       const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
       const layerName = 'testLayer';
       const layerRelativePath = 'testLayerPath';
@@ -46,7 +49,7 @@ describe('mapproxyClient', () => {
       setValue('tilesStorageProvider', 'unsupported');
 
       try {
-        mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }));
+        mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }), tracerMock);
       } catch (err) {
         // eslint-disable-next-line jest/no-conditional-expect
         expect(err).toBeInstanceOf(UnsupportedStorageProviderError);
@@ -56,7 +59,7 @@ describe('mapproxyClient', () => {
     it('should throw an PublishLayerError when mapproxyApi client returns an error', async () => {
       setValue('tilesStorageProvider', 'FS');
 
-      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }));
+      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }), tracerMock);
       const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
       const layerName = 'errorTestLayer';
       const layerRelativePath = 'errorTestLayerPath';
@@ -73,7 +76,7 @@ describe('mapproxyClient', () => {
     it('should update a layer in mapproxy', async () => {
       setValue('tilesStorageProvider', 'FS');
 
-      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }));
+      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }), tracerMock);
       const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
       const layerName = 'test-layer';
       const layerRelativePath = 'bfa79f98-79af-44b2-8acd-6dc1ebb9fd1c/c3959032-c6df-41ba-945a-80633510123a';
@@ -90,7 +93,7 @@ describe('mapproxyClient', () => {
     it('should throw an error for unsupported storage provider', () => {
       setValue('tilesStorageProvider', 'unsupported');
       try {
-        mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }));
+        mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }), tracerMock);
       } catch (err) {
         // eslint-disable-next-line jest/no-conditional-expect
         expect(err).toBeInstanceOf(UnsupportedStorageProviderError);
@@ -100,7 +103,7 @@ describe('mapproxyClient', () => {
     it('should throw an PublishLayerError when mapproxyApi client returns an error', async () => {
       setValue('tilesStorageProvider', 'FS');
 
-      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }));
+      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }), tracerMock);
       const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
       const layerName = 'errorTest-Layer';
       const layerRelativePath = 'bfa79f98-79af-44b2-8acd-6dc1ebb9fd1c/c3959032-c6df-41ba-945a-80633510123a';
@@ -115,7 +118,7 @@ describe('mapproxyClient', () => {
   });
   describe('getCacheName', () => {
     it('should get cache name from mapproxy', async () => {
-      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }));
+      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }), tracerMock);
       const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
       const layerName = 'test-layer';
       const cacheType = LayerCacheType.REDIS;
@@ -133,7 +136,7 @@ describe('mapproxyClient', () => {
     });
 
     it('should throw an error for unsupported layer cache type', async () => {
-      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }));
+      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }), tracerMock);
       const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
       const layerName = 'test-layer';
       const cacheType = LayerCacheType.FS;
@@ -151,7 +154,7 @@ describe('mapproxyClient', () => {
     it('should throw an LayerCacheNotFoundError when mapproxyApi client returns an error', async () => {
       setValue('tilesStorageProvider', 'FS');
 
-      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }));
+      mapproxyApiClient = new MapproxyApiClient(configMock, jsLogger({ enabled: false }), tracerMock);
       const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
       const layerName = 'not-found-layer';
       const cacheType = LayerCacheType.REDIS;

--- a/tests/unit/job/jobProcessor/jobProcessorSetup.ts
+++ b/tests/unit/job/jobProcessor/jobProcessorSetup.ts
@@ -1,5 +1,6 @@
 import { IJobResponse, ITaskResponse } from '@map-colonies/mc-priority-queue';
 import jsLogger from '@map-colonies/js-logger';
+import { trace } from '@opentelemetry/api';
 import { TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
 import { JobProcessor } from '../../../../src/job/models/jobProcessor';
 import { JobHandlerFactory } from '../../../../src/job/models/jobHandlerFactory';
@@ -52,7 +53,8 @@ export function setupJobProcessorTest({ useMockQueueClient = false }: { useMockQ
   );
 
   const queueClient = useMockQueueClient ? mockQueueClient : queueClientInstance;
-  const jobProcessor = new JobProcessor(mockLogger, configMock, mockJobHandlerFactory, queueClient);
+  const tracerMock = trace.getTracer('test');
+  const jobProcessor = new JobProcessor(mockLogger, tracerMock, configMock, mockJobHandlerFactory, queueClient);
   return {
     jobProcessor,
     mockJobHandlerFactory,

--- a/tests/unit/job/newJobHandler/newJobHandlerSetup.ts
+++ b/tests/unit/job/newJobHandler/newJobHandlerSetup.ts
@@ -1,5 +1,5 @@
 import jsLogger from '@map-colonies/js-logger';
-import { trace, Tracer } from '@opentelemetry/api';
+import { trace } from '@opentelemetry/api';
 import { JobManagerClient, TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
 import { TileMergeTaskManager } from '../../../../src/task/models/tileMergeTaskManager';
 import { MapproxyApiClient } from '../../../../src/httpClients/mapproxyClient';

--- a/tests/unit/job/newJobHandler/newJobHandlerSetup.ts
+++ b/tests/unit/job/newJobHandler/newJobHandlerSetup.ts
@@ -1,4 +1,5 @@
 import jsLogger from '@map-colonies/js-logger';
+import { trace, Tracer } from '@opentelemetry/api';
 import { JobManagerClient, TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
 import { TileMergeTaskManager } from '../../../../src/task/models/tileMergeTaskManager';
 import { MapproxyApiClient } from '../../../../src/httpClients/mapproxyClient';
@@ -37,9 +38,11 @@ export const setupNewJobHandlerTest = (): NewJobHandlerTestContext => {
   const mapproxyClientMock = { publish: jest.fn() } as unknown as jest.Mocked<MapproxyApiClient>;
   const geoserverClientMock = { publish: jest.fn() } as unknown as jest.Mocked<GeoserverClient>;
   const catalogClientMock = { publish: jest.fn() } as unknown as jest.Mocked<CatalogClient>;
+  const tracerMock = trace.getTracer('test');
 
   const newJobHandler = new NewJobHandler(
     jsLogger({ enabled: false }),
+    tracerMock,
     taskBuilderMock,
     queueClientMock,
     catalogClientMock,

--- a/tests/unit/job/seedingJobCreator/seedingJobCreatorSetup.ts
+++ b/tests/unit/job/seedingJobCreator/seedingJobCreatorSetup.ts
@@ -1,9 +1,9 @@
 import { JobManagerClient, TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
 import jsLogger from '@map-colonies/js-logger';
+import { trace } from '@opentelemetry/api';
 import { SeedingJobCreator } from '../../../../src/job/models/seedingJobCreator';
 import { MapproxyApiClient } from '../../../../src/httpClients/mapproxyClient';
 import { configMock } from '../../mocks/configMock';
-import { trace } from '@opentelemetry/api';
 
 export interface SeedingJobCreatorTestContext {
   seedingJobCreator: SeedingJobCreator;

--- a/tests/unit/job/seedingJobCreator/seedingJobCreatorSetup.ts
+++ b/tests/unit/job/seedingJobCreator/seedingJobCreatorSetup.ts
@@ -3,6 +3,7 @@ import jsLogger from '@map-colonies/js-logger';
 import { SeedingJobCreator } from '../../../../src/job/models/seedingJobCreator';
 import { MapproxyApiClient } from '../../../../src/httpClients/mapproxyClient';
 import { configMock } from '../../mocks/configMock';
+import { trace } from '@opentelemetry/api';
 
 export interface SeedingJobCreatorTestContext {
   seedingJobCreator: SeedingJobCreator;
@@ -22,8 +23,9 @@ export const setupSeedingJobCreatorTest = (): SeedingJobCreatorTestContext => {
   } as unknown as jest.Mocked<QueueClient>;
 
   const mapproxyClientMock = { getCacheName: jest.fn() } as unknown as jest.Mocked<MapproxyApiClient>;
+  const tracerMock = trace.getTracer('test');
 
-  const seedingJobCreator = new SeedingJobCreator(jsLogger({ enabled: false }), configMock, queueClientMock, mapproxyClientMock);
+  const seedingJobCreator = new SeedingJobCreator(jsLogger({ enabled: false }), tracerMock, configMock, queueClientMock, mapproxyClientMock);
 
   return {
     seedingJobCreator,

--- a/tests/unit/job/swapJobHandler/swapJobHandler.spec.ts
+++ b/tests/unit/job/swapJobHandler/swapJobHandler.spec.ts
@@ -18,7 +18,7 @@ describe('swapJobHandler', () => {
 
   describe('handleJobInit', () => {
     it('should handle job init successfully', async () => {
-      const { swapJobHandler, queueClientMock, taskBuilderMock, jobManagerClientMock } = setupSwapJobHandlerTest();
+      const { swapJobHandler, queueClientMock, taskBuilderMock } = setupSwapJobHandlerTest();
       const job = structuredClone(ingestionSwapUpdateJob);
       const task = initTaskForIngestionSwapUpdate;
 

--- a/tests/unit/job/swapJobHandler/swapJobHandler.spec.ts
+++ b/tests/unit/job/swapJobHandler/swapJobHandler.spec.ts
@@ -45,14 +45,13 @@ describe('swapJobHandler', () => {
       taskBuilderMock.pushTasks.mockResolvedValue(undefined);
       queueClientMock.ack.mockResolvedValue(undefined);
 
+      const completeInitTaskSpy = jest.spyOn(swapJobHandler as unknown as { completeInitTask: jest.Func }, 'completeInitTask');
+
       await swapJobHandler.handleJobInit(job, task);
 
       expect(taskBuilderMock.buildTasks).toHaveBeenCalledWith(taskBuildParams);
       expect(taskBuilderMock.pushTasks).toHaveBeenCalledWith(job.id, job.type, mergeTasks);
-      expect(queueClientMock.ack).toHaveBeenCalledWith(job.id, task.id);
-      expect(jobManagerClientMock.updateJob).toHaveBeenCalledWith(job.id, {
-        parameters: { ...job.parameters, additionalParams: { ...additionalParams, displayPath: newDisplayPath } },
-      });
+      expect(completeInitTaskSpy).toHaveBeenCalledWith(job, task, expect.any(Object));
     });
 
     it('should handle job init failure and reject the task', async () => {

--- a/tests/unit/job/swapJobHandler/swapJobHandlerSetup.ts
+++ b/tests/unit/job/swapJobHandler/swapJobHandlerSetup.ts
@@ -1,5 +1,6 @@
 import jsLogger from '@map-colonies/js-logger';
 import { JobManagerClient, TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
+import { trace } from '@opentelemetry/api';
 import { TileMergeTaskManager } from '../../../../src/task/models/tileMergeTaskManager';
 import { MapproxyApiClient } from '../../../../src/httpClients/mapproxyClient';
 import { CatalogClient } from '../../../../src/httpClients/catalogClient';
@@ -37,9 +38,11 @@ export const setupSwapJobHandlerTest = (): SwapJobHandlerTestContext => {
   const mapproxyClientMock = { update: jest.fn() } as unknown as jest.Mocked<MapproxyApiClient>;
   const catalogClientMock = { update: jest.fn() } as unknown as jest.Mocked<CatalogClient>;
   const seedingJobCreatorMock = { create: jest.fn() } as unknown as jest.Mocked<SeedingJobCreator>;
+  const tracerMock = trace.getTracer('test');
 
   const swapJobHandler = new SwapJobHandler(
     jsLogger({ enabled: false }),
+    tracerMock,
     queueClientMock,
     taskBuilderMock,
     mapproxyClientMock,

--- a/tests/unit/job/updateJobHandler/updateJobHandlerSetup.ts
+++ b/tests/unit/job/updateJobHandler/updateJobHandlerSetup.ts
@@ -1,5 +1,6 @@
 import jsLogger from '@map-colonies/js-logger';
 import { JobManagerClient, TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
+import { trace } from '@opentelemetry/api';
 import { configMock } from '../../mocks/configMock';
 import { TileMergeTaskManager } from '../../../../src/task/models/tileMergeTaskManager';
 import { MapproxyApiClient } from '../../../../src/httpClients/mapproxyClient';
@@ -39,9 +40,10 @@ export const setupUpdateJobHandlerTest = (): UpdateJobHandlerTestContext => {
   const catalogClientMock = { publish: jest.fn(), update: jest.fn() } as unknown as jest.Mocked<CatalogClient>;
 
   const seedingJobCreatorMock = { create: jest.fn() } as unknown as jest.Mocked<SeedingJobCreator>;
-
+  const tracerMock = trace.getTracer('test');
   const updateJobHandler = new UpdateJobHandler(
     jsLogger({ enabled: false }),
+    tracerMock,
     configMock,
     taskBuilderMock,
     queueClientMock,

--- a/tests/unit/mocks/jobsMockData.ts
+++ b/tests/unit/mocks/jobsMockData.ts
@@ -1,6 +1,6 @@
 import { IngestionNewJobParams, IngestionUpdateJobParams, ProductType, TileOutputFormat, Transparency } from '@map-colonies/mc-model-types';
 import { IJobResponse, OperationStatus } from '@map-colonies/mc-priority-queue';
-import { ExtendedNewRasterLayer, Grid } from '../../../src/common/interfaces';
+import { IngestionNewExtendedJobParams, Grid } from '../../../src/common/interfaces';
 import { partsData } from './partsMockData';
 
 /* eslint-disable @typescript-eslint/no-magic-numbers */
@@ -58,7 +58,7 @@ export const ingestionNewJob: IJobResponse<IngestionNewJobParams, unknown> = {
   updated: '2024-07-21T10:59:23.510Z',
 };
 
-export const ingestionNewJobExtended: IJobResponse<ExtendedNewRasterLayer, unknown> = {
+export const ingestionNewJobExtended: IJobResponse<IngestionNewExtendedJobParams, unknown> = {
   ...ingestionNewJob,
   parameters: {
     ...ingestionNewJob.parameters,

--- a/tests/unit/task/tileMergeTaskManager/tileMergeTaskManagerSetup.ts
+++ b/tests/unit/task/tileMergeTaskManager/tileMergeTaskManagerSetup.ts
@@ -2,6 +2,7 @@ import { IJobResponse, ITaskResponse } from '@map-colonies/mc-priority-queue';
 import jsLogger from '@map-colonies/js-logger';
 import { TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
 import { TileRanger } from '@map-colonies/mc-utils';
+import { trace } from '@opentelemetry/api';
 import { configMock } from '../../mocks/configMock';
 import { JobManagerConfig } from '../../../../src/common/interfaces';
 import { TileMergeTaskManager } from '../../../../src/task/models/tileMergeTaskManager';
@@ -41,7 +42,8 @@ export function setupMergeTilesTaskBuilderTest(useMockQueueClient = false): Merg
   );
 
   const queueClient = useMockQueueClient ? mockQueueClient : queueClientInstance;
-  const tileMergeTaskManager = new TileMergeTaskManager(mockLogger, configMock, new TileRanger(), queueClient, taskMetricsMock);
+  const tracerMock = trace.getTracer('test');
+  const tileMergeTaskManager = new TileMergeTaskManager(mockLogger, tracerMock, configMock, new TileRanger(), queueClient, taskMetricsMock);
   return {
     tileMergeTaskManager,
   };


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Further  information:
- Added tracer injection via dependency injection
- Implemented span creation and context management for main handler methods
- Added trace events for key operations (validation, state changes, task completion)
- Added relevant attributes to spans for debugging context
- Ensured proper span cleanup in finally blocks
