### PR TITLE
fix: taskBatch leftovers condition (MAPCO-6587)

### DIFF
--- a/src/task/models/tileMergeTaskManager.ts
+++ b/src/task/models/tileMergeTaskManager.ts
@@ -116,7 +116,7 @@ export class TileMergeTaskManager {
           }
         }
 
-        if (taskBatch.length === this.taskBatchSize) {
+        if (taskBatch.length > 0) {
           logger.info({ msg: 'Pushing leftovers task batch to queue', batchLength: taskBatch.length });
           activeSpan?.addEvent('enqueueTasks.leftovers', { currentTaskBatchSize: taskBatch.length });
           await this.enqueueTasks(jobId, taskBatch);

--- a/tests/unit/task/tileMergeTaskManager/tileMergeTaskManagerSetup.ts
+++ b/tests/unit/task/tileMergeTaskManager/tileMergeTaskManagerSetup.ts
@@ -1,10 +1,11 @@
 import { IJobResponse, ITaskResponse } from '@map-colonies/mc-priority-queue';
 import jsLogger from '@map-colonies/js-logger';
+import { TileOutputFormat } from '@map-colonies/mc-model-types';
 import { TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
 import { TileRanger } from '@map-colonies/mc-utils';
 import { trace } from '@opentelemetry/api';
 import { configMock } from '../../mocks/configMock';
-import { JobManagerConfig } from '../../../../src/common/interfaces';
+import { JobManagerConfig, MergeTaskParameters } from '../../../../src/common/interfaces';
 import { TileMergeTaskManager } from '../../../../src/task/models/tileMergeTaskManager';
 import { taskMetricsMock } from '../../mocks/metricsMock';
 
@@ -47,4 +48,16 @@ export function setupMergeTilesTaskBuilderTest(useMockQueueClient = false): Merg
   return {
     tileMergeTaskManager,
   };
+}
+
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function* createTaskGenerator(numTasks: number): AsyncGenerator<MergeTaskParameters, void, void> {
+  for (let i = 0; i < numTasks; i++) {
+    yield {
+      isNewTarget: true,
+      targetFormat: TileOutputFormat.PNG,
+      sources: [{ path: 'layerRelativePath', type: 'source' }],
+      batches: [{ maxX: 1, maxY: 1, minX: 0, minY: 0, zoom: 1 }],
+    };
+  }
 }


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |



Further  information:
When merging previous pull requests, the condition for pushing the leftover batch was accidentally changed to `taskBatch.length === this.taskBatchSize`. This introduced a bug where, if there was a leftover batch, it would never be pushed because the condition was incorrect.

The fix involved reverting to the original condition: `taskBatch.length > 0`, ensuring that any remaining batch is pushed as intended.
