### PR TITLE
fix: remove -max_old_space_size from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ COPY --chown=node:node ./config ./config
 
 USER node
 EXPOSE 8080
-CMD ["dumb-init", "node", "--max_old_space_size=512", "--require", "./common/tracing.js", "./index.js"]
+CMD ["dumb-init", "node", "--require", "./common/tracing.js", "./index.js"]


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   |✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |


Further  information:
Remove fixed Node.js memory limit to align with Kubernetes resource management

Previously, our Node.js service had a fixed heap size limit of 512MB set via the --max_old_space_size flag. This static limit prevented Kubernetes from effectively managing memory resources based on pod specifications.

By removing this flag, the service will now respect the memory limits defined in the Kubernetes deployment configuration, allowing for more flexible and environment-specific resource allocation.



