### PR TITLE
fix: update @map-colonies/raster-shared to version 1.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@map-colonies/mc-model-types": "^17.15.1",
         "@map-colonies/mc-priority-queue": "^8.1.1",
         "@map-colonies/mc-utils": "^3.2.0",
-        "@map-colonies/raster-shared": "^1.9.0",
+        "@map-colonies/raster-shared": "^1.9.1",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/telemetry": "^7.0.1",
         "@map-colonies/types": "^1.4.0",
@@ -6107,9 +6107,9 @@
       "license": "ISC"
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-1.9.0.tgz",
-      "integrity": "sha512-hKiy6jXNdij52fo7HP9xJt3r30t61JrZlfSW7D5m/GCyE8pMCRyMFHRGwSoweQkP0vvF8wefIybLo7388PSmiw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-1.9.1.tgz",
+      "integrity": "sha512-yaJQ2JZoFkjlfPSkhEAr3qs8CDcBzD3Vv3AQzCcNd1P6vagU0p7F57NGOqgu28uwtsUZC5lwSNeRLnMYJidmpg==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@map-colonies/mc-model-types": "^17.15.1",
     "@map-colonies/mc-priority-queue": "^8.1.1",
     "@map-colonies/mc-utils": "^3.2.0",
-    "@map-colonies/raster-shared": "^1.9.0",
+    "@map-colonies/raster-shared": "^1.9.1",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/telemetry": "^7.0.1",
     "@map-colonies/types": "^1.4.0",


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                       |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Further  information:
using coerce in:
`expirationTime: z.coerce.date().optional()`
on the new version of @map-colonies/raster-shared