### PR TITLE
feat: add featureCollection filter to aggregation and getAggregation metadata in export process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@map-colonies/mc-model-types": "^17.15.1",
         "@map-colonies/mc-priority-queue": "^8.1.1",
         "@map-colonies/mc-utils": "^3.2.0",
-        "@map-colonies/raster-shared": "^1.9.1",
+        "@map-colonies/raster-shared": "^3.0.0",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/telemetry": "^7.0.1",
         "@map-colonies/types": "^1.4.0",
@@ -4385,6 +4385,19 @@
         "@map-colonies/types": "^1.3.5"
       }
     },
+    "node_modules/@map-colonies/mc-model-types/node_modules/@map-colonies/raster-shared": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-1.10.0.tgz",
+      "integrity": "sha512-kkqpxy86u61L21EJMUKEOKhqmTdqAZTJhlvQiVjqjyDjhG3XZB+fxDls7rDOKi4caOwLl/J5Cc2SCyG2iNlBNA==",
+      "license": "ISC",
+      "dependencies": {
+        "@map-colonies/mc-priority-queue": "^8.2.1",
+        "@map-colonies/types": "^1.4.0",
+        "geojson": "^0.5.0",
+        "standard-version": "^9.5.0",
+        "zod": "^3.24.1"
+      }
+    },
     "node_modules/@map-colonies/mc-priority-queue": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/@map-colonies/mc-priority-queue/-/mc-priority-queue-8.2.1.tgz",
@@ -6107,9 +6120,9 @@
       "license": "ISC"
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-1.9.1.tgz",
-      "integrity": "sha512-yaJQ2JZoFkjlfPSkhEAr3qs8CDcBzD3Vv3AQzCcNd1P6vagU0p7F57NGOqgu28uwtsUZC5lwSNeRLnMYJidmpg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-3.0.0.tgz",
+      "integrity": "sha512-xaeQ/7VwIiz6Z8Nv4j3N44pxgTvJhAV7DL6vQHzPyn5IXR0VKwbM2BqKJ1tS97D6kPdiv22DDwkJg3XA2QCaUg==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A geospatial data management worker service that handles initialization, merge, and finalization of geospatial jobs & tasks.",
   "main": "./src/index.ts",
   "scripts": {
-    "test:unit": "jest --config=./tests/configurations/unit/jest.config.js",
+    "test:unit": "jest --config=./tests/configurations/unit/jest.config.js --runInBand",
     "test:integration": "jest --config=./tests/configurations/integration/jest.config.js",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
@@ -50,7 +50,7 @@
     "@map-colonies/mc-model-types": "^17.15.1",
     "@map-colonies/mc-priority-queue": "^8.1.1",
     "@map-colonies/mc-utils": "^3.2.0",
-    "@map-colonies/raster-shared": "^1.9.1",
+    "@map-colonies/raster-shared": "^3.0.0",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/telemetry": "^7.0.1",
     "@map-colonies/types": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A geospatial data management worker service that handles initialization, merge, and finalization of geospatial jobs & tasks.",
   "main": "./src/index.ts",
   "scripts": {
-    "test:unit": "jest --config=./tests/configurations/unit/jest.config.js --runInBand",
+    "test:unit": "jest --config=./tests/configurations/unit/jest.config.js",
     "test:integration": "jest --config=./tests/configurations/integration/jest.config.js",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A geospatial data management worker service that handles initialization, merge, and finalization of geospatial jobs & tasks.",
   "main": "./src/index.ts",
   "scripts": {
-    "test:unit": "jest --config=./tests/configurations/unit/jest.config.js",
+    "test:unit": "jest --config=./tests/configurations/unit/jest.config.js --runInBand",
     "test:integration": "jest --config=./tests/configurations/integration/jest.config.js",
     "format": "prettier --check .",
     "format:fix": "prettier --write .",

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -88,3 +88,12 @@ export class FSError extends Error {
     this.stack = err instanceof Error ? err.stack : undefined;
   }
 }
+
+export class LayerMetadataAggregationError extends Error {
+  public constructor(err: unknown, polygonPartsEntityName: string) {
+    const message = `Failed to get aggregated layer metadata for ${polygonPartsEntityName}: ${err instanceof Error ? err.message : 'unknown'}`;
+    super(message);
+    this.name = LayerMetadataAggregationError.name;
+    this.stack = err instanceof Error ? err.stack : undefined;
+  }
+}

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -264,7 +264,7 @@ export interface PartAggregatedData {
   minResolutionDeg: number;
   maxResolutionMeter: number;
   minResolutionMeter: number;
-  footprint: Polygon;
+  footprint: Polygon | MultiPolygon;
   productBoundingBox: string;
 }
 

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -1,15 +1,16 @@
 import { z } from 'zod';
 import type { ICreateTaskBody, IJobResponse, ITaskResponse } from '@map-colonies/mc-priority-queue';
-import type {
-  InputFiles,
-  PolygonPart,
-  IngestionNewFinalizeTaskParams,
-  IngestionUpdateFinalizeTaskParams,
-  IngestionSwapUpdateFinalizeTaskParams,
-  TileOutputFormat,
-  LayerName,
-  RasterLayerMetadata,
-  TileFormatStrategy,
+import {
+  type InputFiles,
+  type PolygonPart,
+  type IngestionNewFinalizeTaskParams,
+  type IngestionUpdateFinalizeTaskParams,
+  type IngestionSwapUpdateFinalizeTaskParams,
+  type TileOutputFormat,
+  type LayerName,
+  type RasterLayerMetadata,
+  type TileFormatStrategy,
+  aggregationFeatureSchema,
 } from '@map-colonies/raster-shared';
 import type { BBox, Feature, FeatureCollection, MultiPolygon, Polygon } from 'geojson';
 import type { ITileRange } from '@map-colonies/mc-utils';
@@ -254,19 +255,9 @@ export interface InsertGeoserverRequest {
 
 //#region catalogClient
 
-export interface PartAggregatedData {
-  imagingTimeBeginUTC: Date;
-  imagingTimeEndUTC: Date;
-  minHorizontalAccuracyCE90: number;
-  maxHorizontalAccuracyCE90: number;
-  sensors: string[];
-  maxResolutionDeg: number;
-  minResolutionDeg: number;
-  maxResolutionMeter: number;
-  minResolutionMeter: number;
+export type AggregationLayerMetadata = z.infer<typeof aggregationFeatureSchema>['properties'] & {
   footprint: Polygon | MultiPolygon;
-  productBoundingBox: string;
-}
+};
 
 export interface CatalogUpdateRequestBody {
   metadata: CatalogUpdateMetadata;

--- a/src/httpClients/polygonPartsMangerClient.ts
+++ b/src/httpClients/polygonPartsMangerClient.ts
@@ -2,12 +2,12 @@ import type { IConfig } from 'config';
 import type { Logger } from '@map-colonies/js-logger';
 import type { AggregationFeature, RoiFeatureCollection } from '@map-colonies/raster-shared';
 import type { IHttpRetryConfig } from '@map-colonies/mc-utils';
-import { AggregationLayerMetadata } from '@map-colonies/mc-model-types';
 import { HttpClient } from '@map-colonies/mc-utils';
 import { inject, injectable } from 'tsyringe';
 import { SERVICES } from '../common/constants';
 import { requiredAggregationFeatureSchema } from '../utils/zod/schemas/aggregation.schema';
 import { LayerMetadataAggregationError } from '../common/errors';
+import { AggregationLayerMetadata } from '../common/interfaces';
 
 @injectable()
 export class PolygonPartsMangerClient extends HttpClient {

--- a/src/httpClients/polygonPartsMangerClient.ts
+++ b/src/httpClients/polygonPartsMangerClient.ts
@@ -21,8 +21,14 @@ export class PolygonPartsMangerClient extends HttpClient {
 
   public async getAggregatedLayerMetadata(polygonPartsEntityName: string, filter?: RoiFeatureCollection): Promise<AggregationLayerMetadata> {
     try {
-      const url = `${polygonPartsEntityName}/aggregate`;
-      const res = await this.post<AggregationFeature>(url, filter);
+      this.logger.info({ msg: 'getAggregatedLayerMetadata', polygonPartsEntityName, filter });
+
+      const url = `polygonParts/${polygonPartsEntityName}/aggregate`;
+      const body = {
+        filter: filter ?? null,
+      };
+
+      const res = await this.post<AggregationFeature>(url, body);
       const aggregatedLayerMetadata = this.validateAndTransformFeatureToAggregationMetadata(res);
       return aggregatedLayerMetadata;
     } catch (err) {

--- a/src/utils/zod/schemas/aggregation.schema.ts
+++ b/src/utils/zod/schemas/aggregation.schema.ts
@@ -1,0 +1,3 @@
+import { aggregationFeaturePropertiesSchema, featureSchema, multiPolygonSchema, polygonSchema } from '@map-colonies/raster-shared';
+
+export const requiredAggregationFeatureSchema = featureSchema(polygonSchema.or(multiPolygonSchema), aggregationFeaturePropertiesSchema);

--- a/tests/unit/httpClients/catalogClientSetup.ts
+++ b/tests/unit/httpClients/catalogClientSetup.ts
@@ -1,13 +1,15 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { Link } from '@map-colonies/mc-model-types';
 import jsLogger from '@map-colonies/js-logger';
+import { z } from 'zod';
+import { AggregationFeature, aggregationFeaturePropertiesSchema, CORE_VALIDATIONS, INGESTION_VALIDATIONS } from '@map-colonies/raster-shared';
 import { faker } from '@faker-js/faker';
 import { ILinkBuilderData, LinkBuilder } from '../../../src/utils/linkBuilder';
 import { configMock, registerDefaultConfig } from '../mocks/configMock';
 import { CatalogClient } from '../../../src/httpClients/catalogClient';
 import { PolygonPartsMangerClient } from '../../../src/httpClients/polygonPartsMangerClient';
 import { PartAggregatedData } from '../../../src/common/interfaces';
-import { createFakeBBox, createFakePolygon } from '../mocks/partsMockData';
+import { createFakeBBox, createFakeRandomPolygonalGeometry } from '../mocks/partsMockData';
 import { IngestionJobTypes } from '../../../src/utils/configUtil';
 import { tracerMock } from '../mocks/tracerMock';
 
@@ -48,18 +50,36 @@ export function setupCatalogClientTest(): CatalogClientTestContext {
 
 export const linksMockData: Link[] = [];
 
-export const createFakeAggregatedPartData = (): PartAggregatedData => {
+export const createFakeAggregationProperties = (): z.infer<typeof aggregationFeaturePropertiesSchema> => {
+  const resolutionMeter = faker.number.float(INGESTION_VALIDATIONS.resolutionMeter);
+  const horizontalAccuracyCE90 = faker.number.int(INGESTION_VALIDATIONS.horizontalAccuracyCE90);
+  const resolutionDeg = faker.number.float(CORE_VALIDATIONS.resolutionDeg);
   return {
-    footprint: createFakePolygon(),
-    imagingTimeBeginUTC: faker.date.recent(),
+    imagingTimeBeginUTC: faker.date.past(),
     imagingTimeEndUTC: faker.date.recent(),
-    maxHorizontalAccuracyCE90: faker.number.int(),
-    maxResolutionDeg: faker.number.float(),
-    maxResolutionMeter: faker.number.int(),
-    minHorizontalAccuracyCE90: faker.number.int(),
-    minResolutionDeg: faker.number.float(),
-    minResolutionMeter: faker.number.int(),
+    maxResolutionMeter: resolutionMeter,
+    minResolutionMeter: resolutionMeter,
+    maxHorizontalAccuracyCE90: horizontalAccuracyCE90,
+    minHorizontalAccuracyCE90: horizontalAccuracyCE90,
+    maxResolutionDeg: resolutionDeg,
+    minResolutionDeg: resolutionDeg,
     productBoundingBox: createFakeBBox().toString(),
     sensors: [faker.word.noun()],
+  };
+};
+
+export const createFakeAggregatedPartData = (): PartAggregatedData => {
+  const aggregationProps = createFakeAggregationProperties();
+  return {
+    footprint: createFakeRandomPolygonalGeometry(),
+    ...aggregationProps,
+  };
+};
+
+export const createFakeAggregatedFeature = (): AggregationFeature => {
+  return {
+    geometry: createFakeRandomPolygonalGeometry(),
+    type: 'Feature',
+    properties: createFakeAggregationProperties(),
   };
 };

--- a/tests/unit/httpClients/catalogClientSetup.ts
+++ b/tests/unit/httpClients/catalogClientSetup.ts
@@ -8,10 +8,10 @@ import { ILinkBuilderData, LinkBuilder } from '../../../src/utils/linkBuilder';
 import { configMock, registerDefaultConfig } from '../mocks/configMock';
 import { CatalogClient } from '../../../src/httpClients/catalogClient';
 import { PolygonPartsMangerClient } from '../../../src/httpClients/polygonPartsMangerClient';
-import { PartAggregatedData } from '../../../src/common/interfaces';
 import { createFakeBBox, createFakeRandomPolygonalGeometry } from '../mocks/partsMockData';
 import { IngestionJobTypes } from '../../../src/utils/configUtil';
 import { tracerMock } from '../mocks/tracerMock';
+import { AggregationLayerMetadata } from '../../../src/common/interfaces';
 
 const jobTypes: IngestionJobTypes = {
   Ingestion_New: 'Ingestion_New',
@@ -68,7 +68,7 @@ export const createFakeAggregationProperties = (): z.infer<typeof aggregationFea
   };
 };
 
-export const createFakeAggregatedPartData = (): PartAggregatedData => {
+export const createFakeAggregatedPartData = (): AggregationLayerMetadata => {
   const aggregationProps = createFakeAggregationProperties();
   return {
     footprint: createFakeRandomPolygonalGeometry(),

--- a/tests/unit/httpClients/polygonPartMangerClient.spec.ts
+++ b/tests/unit/httpClients/polygonPartMangerClient.spec.ts
@@ -1,9 +1,12 @@
 import jsLogger from '@map-colonies/js-logger';
 import { faker } from '@faker-js/faker';
+import { AggregationFeature, RoiFeatureCollection } from '@map-colonies/raster-shared';
 import nock from 'nock';
 import { PolygonPartsMangerClient } from '../../../src/httpClients/polygonPartsMangerClient';
+import { createFakeRoiFeatureCollection } from '../mocks/exportMockData';
+import { LayerMetadataAggregationError } from '../../../src/common/errors';
 import { configMock, registerDefaultConfig } from '../mocks/configMock';
-import { createFakeAggregatedPartData } from './catalogClientSetup';
+import { createFakeAggregatedFeature } from './catalogClientSetup';
 
 describe('polygonPartsManagerClient', () => {
   let polygonPartsManagerClient: PolygonPartsMangerClient;
@@ -16,25 +19,43 @@ describe('polygonPartsManagerClient', () => {
   });
 
   describe('getAggregatedLayerMetadata', () => {
-    it('should return aggregated part data', async () => {
+    it('should return aggregated part data based on polygonPartsEntityName', async () => {
       polygonPartsManagerClient = new PolygonPartsMangerClient(configMock, jsLogger({ enabled: false }));
 
       const baseUrl = configMock.get<string>('servicesUrl.polygonPartsManager');
-      const catalogId = faker.string.uuid();
-      const aggregatedPartData = createFakeAggregatedPartData();
-      nock(baseUrl).get(`/aggregation/${catalogId}`).reply(200, aggregatedPartData);
+      const polygonPartsEntityName = 'bluemarble_orthophoto';
+      const aggregatedFeature = createFakeAggregatedFeature();
+      const url = `/${polygonPartsEntityName}/aggregate`;
+      nock(baseUrl).post(url).reply(200, aggregatedFeature);
 
-      const action = polygonPartsManagerClient.getAggregatedLayerMetadata(catalogId);
-      const result = {
-        ...aggregatedPartData,
-        imagingTimeBeginUTC: aggregatedPartData.imagingTimeBeginUTC.toISOString(),
-        imagingTimeEndUTC: aggregatedPartData.imagingTimeEndUTC.toISOString(),
+      const action = polygonPartsManagerClient.getAggregatedLayerMetadata(polygonPartsEntityName);
+      const expectedResult = {
+        footprint: aggregatedFeature.geometry,
+        ...aggregatedFeature.properties,
       };
-      await expect(action).resolves.toEqual(result);
+
+      await expect(action).resolves.toEqual(expectedResult);
       expect(nock.isDone()).toBe(true);
     });
 
-    it('should throw an error when the request fails', async () => {
+    it('should return aggregated part data based on polygonPartsEntityName and filter', async () => {
+      polygonPartsManagerClient = new PolygonPartsMangerClient(configMock, jsLogger({ enabled: false }));
+      const baseUrl = configMock.get<string>('servicesUrl.polygonPartsManager');
+      const polygonPartsEntityName = 'bluemarble_orthophoto';
+      const filter: RoiFeatureCollection = createFakeRoiFeatureCollection();
+      const aggregatedFeature = createFakeAggregatedFeature();
+      const url = `/${polygonPartsEntityName}/aggregate`;
+      nock(baseUrl).post(url, JSON.stringify(filter)).reply(200, aggregatedFeature);
+      const action = polygonPartsManagerClient.getAggregatedLayerMetadata(polygonPartsEntityName, filter);
+      const expectedResult = {
+        footprint: aggregatedFeature.geometry,
+        ...aggregatedFeature.properties,
+      };
+      await expect(action).resolves.toEqual(expectedResult);
+      expect(nock.isDone()).toBe(true);
+    });
+
+    it('should throw an LayerMetadataAggregationError when the request fails', async () => {
       polygonPartsManagerClient = new PolygonPartsMangerClient(configMock, jsLogger({ enabled: false }));
 
       const baseUrl = configMock.get<string>('servicesUrl.polygonPartsManager');
@@ -42,10 +63,10 @@ describe('polygonPartsManagerClient', () => {
       nock(baseUrl).get(`/aggregation/${catalogId}`).reply(500);
 
       const action = polygonPartsManagerClient.getAggregatedLayerMetadata(catalogId);
-      await expect(action).rejects.toThrow();
+      await expect(action).rejects.toThrow(LayerMetadataAggregationError);
     });
 
-    it('should throw an error when the entity does not exist', async () => {
+    it('should throw an LayerMetadataAggregationError when the entity does not exist', async () => {
       polygonPartsManagerClient = new PolygonPartsMangerClient(configMock, jsLogger({ enabled: false }));
 
       const baseUrl = configMock.get<string>('servicesUrl.polygonPartsManager');
@@ -53,7 +74,24 @@ describe('polygonPartsManagerClient', () => {
       nock(baseUrl).get(`/aggregation/${catalogId}`).reply(404);
 
       const action = polygonPartsManagerClient.getAggregatedLayerMetadata(catalogId);
-      await expect(action).rejects.toThrow();
+      await expect(action).rejects.toThrow(LayerMetadataAggregationError);
+    });
+
+    it('Should throw a LayerMetadataAggregationError error when the response returns invalid due to filtering', async () => {
+      polygonPartsManagerClient = new PolygonPartsMangerClient(configMock, jsLogger({ enabled: false }));
+      const baseUrl = configMock.get<string>('servicesUrl.polygonPartsManager');
+      const polygonPartsEntityName = 'bluemarble_orthophoto';
+      const filter: RoiFeatureCollection = createFakeRoiFeatureCollection();
+      const aggregatedFeature: AggregationFeature = {
+        type: 'Feature',
+        geometry: null,
+        properties: null,
+      };
+      const url = `/${polygonPartsEntityName}/aggregate`;
+      nock(baseUrl).post(url, JSON.stringify(filter)).reply(200, aggregatedFeature);
+      const action = polygonPartsManagerClient.getAggregatedLayerMetadata(polygonPartsEntityName, filter);
+
+      await expect(action).rejects.toThrow(LayerMetadataAggregationError);
     });
   });
 });

--- a/tests/unit/job/exportJobHandler/exportJobHandler.spec.ts
+++ b/tests/unit/job/exportJobHandler/exportJobHandler.spec.ts
@@ -6,6 +6,7 @@ import { EXPORT_FAILURE_MESSAGE } from '../../../../src/common/constants';
 import { ExportTask } from '../../../../src/common/interfaces';
 import { LayerNotFoundError } from '../../../../src/common/errors';
 import { clear, registerDefaultConfig, setValue } from '../../mocks/configMock';
+import { createFakeAggregatedPartData } from '../../httpClients/catalogClientSetup';
 import { finalizeFailureTaskForExport, finalizeSuccessTaskForExport, initTaskForExport } from '../../mocks/tasksMockData';
 import { exportJob } from '../../mocks/jobsMockData';
 import { layerRecord } from '../../mocks/catalogClientMockData';
@@ -174,7 +175,7 @@ describe('ExportJobHandler', () => {
 
     describe('when handling GPKG file modification', () => {
       it('should modify GPKG metadata and update file size', async () => {
-        const { exportJobHandler, gpkgServiceMock, fsServiceMock, jobManagerClientMock } = setupExportJobHandlerTest();
+        const { exportJobHandler, gpkgServiceMock, fsServiceMock, jobManagerClientMock, polygonPartsManagerClientMock } = setupExportJobHandlerTest();
 
         const job = {
           ...exportJob,
@@ -193,8 +194,11 @@ describe('ExportJobHandler', () => {
             gpkgModified: false,
           },
         };
+
+        const aggregatedLayerMetadata = createFakeAggregatedPartData();
         const fileSize = 1024;
 
+        polygonPartsManagerClientMock.getAggregatedLayerMetadata.mockResolvedValue(aggregatedLayerMetadata);
         gpkgServiceMock.createTableFromMetadata.mockReturnValue(true);
         fsServiceMock.getFileSize.mockResolvedValue(fileSize);
         jobManagerClientMock.updateJob.mockResolvedValue(undefined);

--- a/tests/unit/job/exportJobHandler/exportJobHandlerSetup.ts
+++ b/tests/unit/job/exportJobHandler/exportJobHandlerSetup.ts
@@ -13,6 +13,7 @@ import { GeoPackageClient } from '../../../../src/utils/db/geoPackageClient';
 import { FSService } from '../../../../src/utils/storage/fsService';
 import { CallbackClient } from '../../../../src/httpClients/callbackClient';
 import { JobTrackerClient } from '../../../../src/httpClients/jobTrackerClient';
+import { PolygonPartsMangerClient } from '../../../../src/httpClients/polygonPartsMangerClient';
 
 export interface ExportJobHandlerTestContext {
   configMock: IConfig;
@@ -26,6 +27,7 @@ export interface ExportJobHandlerTestContext {
   fsServiceMock: jest.Mocked<FSService>;
   callbackClientMock: jest.Mocked<CallbackClient>;
   jobTrackerClientMock: jest.Mocked<JobTrackerClient>;
+  polygonPartsManagerClientMock: jest.Mocked<PolygonPartsMangerClient>;
 }
 
 export const setupExportJobHandlerTest = (): ExportJobHandlerTestContext => {
@@ -52,6 +54,10 @@ export const setupExportJobHandlerTest = (): ExportJobHandlerTestContext => {
     send: jest.fn(),
   } as unknown as jest.Mocked<CallbackClient>;
 
+  const polygonPartsManagerClientMock = {
+    getAggregatedLayerMetadata: jest.fn(),
+  } as unknown as jest.Mocked<PolygonPartsMangerClient>;
+
   const exportJobHandler = new ExportJobHandler(
     jsLogger({ enabled: false }),
     configMock,
@@ -64,7 +70,8 @@ export const setupExportJobHandlerTest = (): ExportJobHandlerTestContext => {
     fsServiceMock,
     callbackClientMock,
     gpkgServiceMock,
-    taskMetricsMock
+    taskMetricsMock,
+    polygonPartsManagerClientMock
   );
 
   return {
@@ -79,5 +86,6 @@ export const setupExportJobHandlerTest = (): ExportJobHandlerTestContext => {
     fsServiceMock,
     callbackClientMock,
     jobTrackerClientMock,
+    polygonPartsManagerClientMock,
   };
 };

--- a/tests/unit/mocks/exportMockData.ts
+++ b/tests/unit/mocks/exportMockData.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker';
-import { RoiFeature, RoiFeatureCollection } from '@map-colonies/raster-shared';
+import { CORE_VALIDATIONS, RoiFeature, RoiFeatureCollection } from '@map-colonies/raster-shared';
 import { createFakePolygon } from './partsMockData';
 
 export function createFakeRoiFeature(): RoiFeature {
@@ -7,8 +7,8 @@ export function createFakeRoiFeature(): RoiFeature {
     geometry: createFakePolygon(),
     type: 'Feature',
     properties: {
-      maxResolutionDeg: faker.number.float({ min: 0, max: 1 }),
-      minResolutionDeg: faker.number.float({ min: 0, max: 1 }),
+      maxResolutionDeg: faker.number.float(CORE_VALIDATIONS.resolutionDeg),
+      minResolutionDeg: faker.number.float(CORE_VALIDATIONS.resolutionDeg),
     },
   };
 }

--- a/tests/unit/mocks/partsMockData.ts
+++ b/tests/unit/mocks/partsMockData.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
 import { faker } from '@faker-js/faker';
-import { BBox, Polygon } from 'geojson';
+import { BBox, MultiPolygon, Polygon } from 'geojson';
 import { PolygonPart } from '@map-colonies/raster-shared';
 import { PolygonFeature, PPFeatureCollection } from '../../../src/common/interfaces';
 
@@ -27,6 +27,28 @@ export function createFakePolygon(): Polygon {
       ],
     ],
   };
+}
+
+export function createFakeMultiPolygon(polygonCount: number = 3): MultiPolygon {
+  const polygonCoordinates: number[][][][] = [];
+
+  for (let i = 0; i < polygonCount; i++) {
+    const polygon = createFakePolygon();
+    polygonCoordinates.push(polygon.coordinates);
+  }
+
+  return {
+    type: 'MultiPolygon',
+    coordinates: polygonCoordinates,
+  };
+}
+
+export function createFakeRandomPolygonalGeometry(): Polygon | MultiPolygon {
+  const randomNumber = faker.number.int({ min: 0, max: 1 });
+  if (randomNumber === 0) {
+    return createFakePolygon();
+  }
+  return createFakeMultiPolygon(faker.number.int({ min: 1, max: 5 }));
 }
 
 export function createFakePolygonFeature(): PolygonFeature {


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✖                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |
| Refactor   | ✔                                                                        |


Further  information:

Refactor & Feature: Update PolygonPartsManagerClient response format, implement aggregation validation and use aggregation metadata in export process

This PR contains two main changes:

1. Refactored PolygonPartsManagerClient to use GeoJSON Feature format instead of simple JSON objects, standardizing our geospatial data representation and improving interoperability with other GIS tools.

2. Implemented functionality to  validate metadata for polygon aggregation, ensuring data integrity and using it for export processes.

Changes include:
- Modified response parsing to work with GeoJSON Feature structure
- Implemented validation logic for export parameters
- Added error handling for invalid aggregation requests
- Updated type definitions and tests to reflect new formats
- Maintained backward compatibility with existing consumers