### PR TITLE
fix(seeding-job): reverted producer name to check for undefinied if n…

### DIFF
--- a/src/job/models/ingestion/seedingJobCreator.ts
+++ b/src/job/models/ingestion/seedingJobCreator.ts
@@ -81,7 +81,7 @@ export class SeedingJobCreator {
           type: this.seedJobType,
           parameters: {},
           status: OperationStatus.IN_PROGRESS,
-          producerName: producerName,
+          producerName: producerName ?? undefined,
           productType,
           domain,
           tasks: seedTasks,


### PR DESCRIPTION

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change |✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

while creating an Seeding task - producerName cannot be null but must check for undefined in order that job will be created and ignore it
