### PR TITLE
fix: callbacks sending in export finalize

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@map-colonies/mc-model-types": "^17.15.1",
         "@map-colonies/mc-priority-queue": "^8.1.1",
         "@map-colonies/mc-utils": "^3.2.0",
-        "@map-colonies/raster-shared": "^3.1.0",
+        "@map-colonies/raster-shared": "^3.1.4",
         "@map-colonies/read-pkg": "0.0.1",
         "@map-colonies/telemetry": "^7.0.1",
         "@map-colonies/types": "^1.4.0",
@@ -29,7 +29,6 @@
         "@opentelemetry/api-metrics": "0.23.0",
         "@turf/turf": "^7.0.0",
         "@types/lodash.set": "^4.3.9",
-        "better-sqlite3": "^11.8.1",
         "change-case": "^4.1.2",
         "compression": "^1.7.4",
         "config": "^3.3.9",
@@ -52,7 +51,6 @@
         "@map-colonies/eslint-config": "^4.0.0",
         "@map-colonies/prettier-config": "0.0.1",
         "@map-colonies/standard-version-update-helm-version": "^2.0.1",
-        "@types/better-sqlite3": "^7.6.12",
         "@types/compression": "^1.7.2",
         "@types/config": "^3.3.0",
         "@types/express": "^4.17.17",
@@ -6088,9 +6086,9 @@
       "license": "ISC"
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-3.1.0.tgz",
-      "integrity": "sha512-rbdKT9nm7k+ImwCzcGNRiyowkcGLBOqoBOizmttTF6bWSQ95NNBAgadpQq/D9ul3/CeI/V5tlfLJepr/NH//bA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-3.1.4.tgz",
+      "integrity": "sha512-RDjwcT8AJ809Q72hK+mL5fs7WCEMqiz6ypZIjiW3HFDsI2zvFReQzUA5v6iw/tJut3oCF22nwxZMplYDSy0acg==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^8.2.1",
@@ -11099,16 +11097,6 @@
         "@babel/types": "^7.20.7"
       }
     },
-    "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.5",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
@@ -12969,17 +12957,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/better-sqlite3": {
-      "version": "11.9.1",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.9.1.tgz",
-      "integrity": "sha512-Ba0KR+Fzxh2jDRhdg6TSH0SJGzb8C0aBY4hR8w8madIdIzzC6Y1+kx5qR6eS1Z+Gy20h6ZU28aeyg0z1VIrShQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      }
-    },
     "node_modules/bignumber.js": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.0.tgz",
@@ -12987,15 +12964,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
       }
     },
     "node_modules/bintrees": {
@@ -13008,6 +12976,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
@@ -13019,6 +12988,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -13033,6 +13003,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -13401,12 +13372,6 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
     },
     "node_modules/ci-info": {
       "version": "3.9.0",
@@ -14963,21 +14928,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -15003,15 +14953,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -15137,15 +15078,6 @@
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
       "integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
       "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -16710,15 +16642,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
@@ -17016,12 +16939,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
-    },
     "node_modules/filelist": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
@@ -17301,12 +17218,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "11.3.0",
@@ -17745,12 +17656,6 @@
       "dependencies": {
         "ini": "^1.3.2"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -20473,18 +20378,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -20550,12 +20443,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/modify-values": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz",
@@ -20593,12 +20480,6 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -20661,18 +20542,6 @@
       },
       "engines": {
         "node": ">= 10.13"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.75.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.75.0.tgz",
-      "integrity": "sha512-OhYaY5sDsIka7H7AtijtI9jwGYLyl29eQn/W623DiN/MIv5sUqc4g7BIDThX+gb7di9f6xK02nkp8sdfFWZLTg==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/node-fetch": {
@@ -21678,32 +21547,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -22157,30 +22000,6 @@
       "license": "MIT",
       "dependencies": {
         "quickselect": "^2.0.0"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -23127,51 +22946,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -23923,57 +23697,6 @@
         "tinyqueue": "^2.0.0"
       }
     },
-    "node_modules/tar-fs": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
-      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tar-stream/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/tar-stream/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/tdigest": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
@@ -24416,18 +24139,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
     },
     "node_modules/turf-jsts": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@map-colonies/mc-model-types": "^17.15.1",
     "@map-colonies/mc-priority-queue": "^8.1.1",
     "@map-colonies/mc-utils": "^3.2.0",
-    "@map-colonies/raster-shared": "^3.1.0",
+    "@map-colonies/raster-shared": "^3.1.4",
     "@map-colonies/read-pkg": "0.0.1",
     "@map-colonies/telemetry": "^7.0.1",
     "@map-colonies/types": "^1.4.0",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,5 +1,3 @@
-import { OperationStatus } from '@map-colonies/mc-priority-queue';
-import { CallbacksStatus } from '@map-colonies/raster-shared';
 import { readPackageJsonSync } from '@map-colonies/read-pkg';
 
 export const SERVICE_NAME = readPackageJsonSync().name ?? 'unknown_service';

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -55,6 +55,3 @@ export const SeedMode = {
 } as const;
 
 export type SeedMode = (typeof SeedMode)[keyof typeof SeedMode];
-
-export type CompletedOrFailedStatus = Exclude<CallbacksStatus, OperationStatus.IN_PROGRESS>;
-/* eslint-enable @typescript-eslint/naming-convention */

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { Logger } from '@map-colonies/js-logger';
 import type { ICreateTaskBody, IJobResponse, ITaskResponse } from '@map-colonies/mc-priority-queue';
 import {
   type InputFiles,
@@ -23,7 +24,6 @@ import {
   ingestionNewExtendedJobParamsSchema,
 } from '../utils/zod/schemas/jobParameters.schema';
 import { LayerCacheType, SeedMode } from './constants';
-import { Logger } from '@map-colonies/js-logger';
 
 export type StepKey<T> = keyof T & { [K in keyof T]: T[K] extends boolean ? K : never }[keyof T]; // this is a utility type that extracts the keys of T that are of type boolean
 

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -15,7 +15,7 @@ import {
 import type { BBox, Feature, FeatureCollection, MultiPolygon, Polygon } from 'geojson';
 import type { ITileRange } from '@map-colonies/mc-utils';
 import type { Span, SpanContext } from '@opentelemetry/api';
-import type { IngestionSwapUpdateFinalizeJob, IngestionUpdateFinalizeJob } from '../utils/zod/schemas/job.schema';
+import type { ExportFinalizeTask, ExportJob, IngestionSwapUpdateFinalizeJob, IngestionUpdateFinalizeJob } from '../utils/zod/schemas/job.schema';
 import {
   ingestionSwapUpdateFinalizeJobParamsSchema,
   ingestionUpdateFinalizeJobParamsSchema,
@@ -23,6 +23,7 @@ import {
   ingestionNewExtendedJobParamsSchema,
 } from '../utils/zod/schemas/jobParameters.schema';
 import { LayerCacheType, SeedMode } from './constants';
+import { Logger } from '@map-colonies/js-logger';
 
 export type StepKey<T> = keyof T & { [K in keyof T]: T[K] extends boolean ? K : never }[keyof T]; // this is a utility type that extracts the keys of T that are of type boolean
 
@@ -219,6 +220,24 @@ export type GpkgArtifactProperties = Omit<RasterLayerMetadata, 'productStatus' |
 export type JsonArtifactProperties = Omit<RasterLayerMetadata, 'productStatus'> & { sha256: string };
 
 //#endregion exportTask
+
+//#region exportFinalizeTask
+
+export interface ExportFinalizeExecutionContext {
+  job: ExportJob;
+  task: ExportFinalizeTask;
+  paths: ExportFinalizeGpkgPaths;
+  telemetry: JobAndTaskTelemetry;
+  logger: Logger;
+}
+
+export interface ExportFinalizeGpkgPaths {
+  gpkgFilePath: string;
+  gpkgRelativePath: string;
+  gpkgDirPath: string;
+}
+
+//#endregion exportFinalizeTask
 
 //#region mapproxyApi
 export interface PublishMapLayerRequest {

--- a/src/httpClients/jobTrackerClient.ts
+++ b/src/httpClients/jobTrackerClient.ts
@@ -37,10 +37,12 @@ export class JobTrackerClient extends HttpClient {
         activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Notification sent successfully' });
       } catch (err) {
         if (err instanceof Error) {
+          const message = 'Failed to notify job tracker';
+          const error = new Error(`${message}: ${err.message}`);
           logger.error({ msg: 'Failed to notify job tracker', error: err });
-          activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
-          activeSpan?.recordException(err);
-          throw err;
+          activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+          activeSpan?.recordException(error);
+          throw error;
         }
       } finally {
         activeSpan?.end();

--- a/src/job/models/export/exportJobHandler.ts
+++ b/src/job/models/export/exportJobHandler.ts
@@ -2,13 +2,20 @@ import path from 'path';
 import { Feature, MultiPolygon, Polygon } from 'geojson';
 import { ogr2ogr } from 'ogr2ogr';
 import { inject, injectable } from 'tsyringe';
-import { CallbackExportResponse, callbackExportResponseSchema, CallbacksStatus, CleanupData, RasterLayerMetadata } from '@map-colonies/raster-shared';
+import {
+  CallbackExportResponse,
+  callbackExportResponseSchema,
+  CallbacksStatus,
+  CleanupData,
+  ExportFinalizeFullProcessingParams,
+  ExportFinalizeType,
+  RasterLayerMetadata,
+} from '@map-colonies/raster-shared';
 import { type Logger } from '@map-colonies/js-logger';
 import { context, trace, Tracer } from '@opentelemetry/api';
 import { ArtifactRasterType } from '@map-colonies/types';
 import { OperationStatus, TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
 import {
-  CompletedOrFailedStatus,
   EXPORT_FAILURE_MESSAGE,
   EXPORT_SUCCESS_MESSAGE,
   GPKG_CONTENT_TYPE,
@@ -26,17 +33,9 @@ import {
   GpkgArtifactProperties,
   IConfig,
   IJobHandler,
-  JobAndTaskTelemetry,
   JsonArtifactProperties,
 } from '../../../common/interfaces';
-import {
-  ExportJob,
-  ExportInitTask,
-  ExportFinalizeTask,
-  ExportFinalizeTaskParams,
-  ExportFinalizeSuccessTaskParams,
-  ExportFinalizeFailureTaskParams,
-} from '../../../utils/zod/schemas/job.schema';
+import { ExportJob, ExportInitTask, ExportFinalizeTask, ExportFinalizeTaskParams, exportJobSchema } from '../../../utils/zod/schemas/job.schema';
 import { S3Service } from '../../../utils/storage/s3Service';
 import { CatalogClient } from '../../../httpClients/catalogClient';
 import { internalIdSchema } from '../../../utils/zod/schemas/jobParameters.schema';
@@ -69,7 +68,7 @@ export class ExportJobHandler extends JobHandler implements IJobHandler<ExportJo
     private readonly taskMetrics: TaskMetrics,
     private readonly polygonPartsManagerClient: PolygonPartsMangerClient
   ) {
-    super(logger, queueClient, jobTrackerClient);
+    super(logger, config, queueClient, jobTrackerClient);
     this.exportTaskType = config.get<string>('jobManagement.export.tasks.tilesExporting.type');
     this.gpkgsPath = config.get<string>('jobManagement.polling.jobs.export.gpkgsPath');
     // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -126,88 +125,78 @@ export class ExportJobHandler extends JobHandler implements IJobHandler<ExportJo
         const monitorAttributes = { jobId: job.id, taskId: task.id, jobType: job.type, taskType: task.type };
         const logger = this.logger.child(monitorAttributes);
         const taskProcessTracking = this.taskMetrics.trackTaskProcessing(job.type, task.type);
+        const gpkgRelativePath = job.parameters.additionalParams.packageRelativePath;
+        const gpkgFilePath = path.join(this.gpkgsPath, gpkgRelativePath);
+        const gpkgDirPath = path.dirname(gpkgFilePath);
 
+        let finalizeParams: ExportFinalizeTaskParams = task.parameters;
         try {
           activeSpan?.setAttributes(monitorAttributes);
 
-          const gpkgRelativePath = job.parameters.additionalParams.packageRelativePath;
-          const gpkgFilePath = path.join(this.gpkgsPath, gpkgRelativePath);
-          const gpkgDirPath = path.dirname(gpkgFilePath);
-          let finalizeParams = task.parameters;
-
           logger.info({ msg: `Handling ${job.type} job finalization`, taskType: task.type });
 
-          if (finalizeParams.status === OperationStatus.FAILED) {
-            await this.handleFailedFinalizeTask(job, task, finalizeParams, gpkgDirPath, {
-              taskTracker: taskProcessTracking,
-              tracingSpan: activeSpan,
+          if (task.parameters.type === ExportFinalizeType.Error_Callback) {
+            logger.warn({ msg: `Finalize task type is ${task.parameters.type}, skipping finalize steps and sending failure callbacks` });
+          }
+
+          if (task.parameters.type === ExportFinalizeType.Full_Processing) {
+            let fullProcessingParams = task.parameters;
+            let gpkgProcessingComplete = false;
+            if (!fullProcessingParams.gpkgModified) {
+              activeSpan?.addEvent('gpkg.modification.started');
+              fullProcessingParams = await this.modifyGpkgFile(gpkgFilePath, job, task.id, fullProcessingParams);
+              activeSpan?.addEvent('gpkg.modification.completed', { success: fullProcessingParams.gpkgModified });
+            }
+
+            const shouldUploadToS3 = this.isS3GpkgProvider && fullProcessingParams.gpkgModified && !fullProcessingParams.gpkgUploadedToS3;
+
+            logger.info({
+              msg: 'Should upload to S3',
+              shouldUploadToS3,
+              isS3GpkgProvider: this.isS3GpkgProvider,
+              gpkgModified: fullProcessingParams.gpkgModified,
+              gpkgUploadedToS3: fullProcessingParams.gpkgUploadedToS3,
             });
-            return;
-          }
 
-          if (!finalizeParams.gpkgModified) {
-            activeSpan?.addEvent('gpkg.modification.started');
-            finalizeParams = await this.modifyGpkgFile(gpkgFilePath, job, task.id, finalizeParams);
-            activeSpan?.addEvent('gpkg.modification.completed', { success: finalizeParams.gpkgModified });
-          }
+            if (shouldUploadToS3) {
+              activeSpan?.addEvent('s3.upload.started');
+              fullProcessingParams = await this.uploadGpkgToS3(gpkgFilePath, gpkgRelativePath, job.id, task.id, fullProcessingParams);
+              activeSpan?.addEvent('s3.upload.completed', { success: fullProcessingParams.gpkgUploadedToS3 });
+            }
 
-          const shouldUploadToS3 = this.isS3GpkgProvider && finalizeParams.gpkgModified && !finalizeParams.gpkgUploadedToS3;
+            const bypassS3OrUploaded = !this.isS3GpkgProvider || fullProcessingParams.gpkgUploadedToS3;
+            gpkgProcessingComplete = fullProcessingParams.gpkgModified && bypassS3OrUploaded;
 
-          logger.info({
-            msg: 'Should upload to S3',
-            shouldUploadToS3,
-            isS3GpkgProvider: this.isS3GpkgProvider,
-            gpkgModified: finalizeParams.gpkgModified,
-            gpkgUploadedToS3: finalizeParams.gpkgUploadedToS3,
-          });
+            logger.info({
+              msg: 'GPKG processing completed',
+              success: gpkgProcessingComplete,
+              gpkgModified: fullProcessingParams.gpkgModified,
+              bypassS3OrUploaded,
+            });
 
-          if (shouldUploadToS3) {
-            activeSpan?.addEvent('s3.upload.started');
-            finalizeParams = await this.uploadGpkgToS3(gpkgFilePath, gpkgRelativePath, job.id, task.id, finalizeParams);
-            activeSpan?.addEvent('s3.upload.completed', { success: finalizeParams.gpkgUploadedToS3 });
-          }
-
-          const bypassS3OrUploaded = !this.isS3GpkgProvider || finalizeParams.gpkgUploadedToS3;
-          const gpkgProcessingComplete = finalizeParams.gpkgModified && bypassS3OrUploaded;
-
-          logger.info({
-            msg: 'GPKG processing completed',
-            success: gpkgProcessingComplete,
-            gpkgModified: finalizeParams.gpkgModified,
-            bypassS3OrUploaded,
-          });
-
-          if (gpkgProcessingComplete && !finalizeParams.callbacksSent) {
-            activeSpan?.addEvent('callbacks.sending.started');
-            await this.sendCallbacks(job, task.id, finalizeParams, gpkgDirPath);
-            activeSpan?.addEvent('callbacks.sending.completed');
-          }
-
-          if (gpkgProcessingComplete) {
-            activeSpan?.addEvent('all.steps.completed');
-            logger.info({ msg: 'All finalize steps completed successfully' });
-            await this.completeTask(job, task, { taskTracker: taskProcessTracking, tracingSpan: activeSpan });
+            if (gpkgProcessingComplete) {
+              activeSpan?.addEvent('all.steps.completed');
+              logger.info({ msg: 'All finalize steps completed successfully' });
+              await this.completeTask(job, task, { taskTracker: taskProcessTracking, tracingSpan: activeSpan });
+            }
+            finalizeParams = fullProcessingParams;
           }
         } catch (err) {
           await this.handleError(err, job, task, { taskTracker: taskProcessTracking, tracingSpan: activeSpan });
         } finally {
+          const updatedJob = await this.queueClient.jobManagerClient.getJob(job.id);
+          const validJob = exportJobSchema.parse(updatedJob);
+          const shouldSendCallbacks =
+            (validJob.status === OperationStatus.COMPLETED || validJob.status === OperationStatus.FAILED) && !finalizeParams.callbacksSent;
+          if (shouldSendCallbacks) {
+            activeSpan?.addEvent('callbacks.sending.started');
+            await this.sendCallbacks(validJob, task.id, finalizeParams, gpkgDirPath);
+            activeSpan?.addEvent('callbacks.sending.completed');
+          }
           activeSpan?.end();
         }
       }
     );
-  }
-
-  private async handleFailedFinalizeTask(
-    job: ExportJob,
-    task: ExportFinalizeTask,
-    finalizeParams: ExportFinalizeFailureTaskParams,
-    gpkgDirPath: string,
-    telemetry: JobAndTaskTelemetry
-  ): Promise<void> {
-    this.logger.info({ msg: 'Processing failed finalize task' });
-    await this.updateCallbackParams(job, OperationStatus.FAILED, { errorReason: EXPORT_FAILURE_MESSAGE });
-    await this.sendCallbacks(job, task.id, finalizeParams, gpkgDirPath);
-    await this.completeTask(job, task, telemetry);
   }
 
   private createExportTask(job: ExportJob, metadata: RasterLayerMetadata): ExportTask {
@@ -245,8 +234,8 @@ export class ExportJobHandler extends JobHandler implements IJobHandler<ExportJo
     gpkgFilePath: string,
     job: ExportJob,
     taskId: string,
-    taskParams: ExportFinalizeSuccessTaskParams
-  ): Promise<ExportFinalizeSuccessTaskParams> {
+    taskParams: ExportFinalizeFullProcessingParams
+  ): Promise<ExportFinalizeFullProcessingParams> {
     const logger = this.logger.child({ jobId: job.id, taskId });
 
     const validInternalId = internalIdSchema.parse(job).internalId;
@@ -330,8 +319,8 @@ export class ExportJobHandler extends JobHandler implements IJobHandler<ExportJo
     gpkgRelativePath: string,
     jobId: string,
     taskId: string,
-    taskParams: ExportFinalizeSuccessTaskParams
-  ): Promise<ExportFinalizeSuccessTaskParams> {
+    taskParams: ExportFinalizeFullProcessingParams
+  ): Promise<ExportFinalizeFullProcessingParams> {
     const gpkgS3Key = `${GPKGS_PREFIX}/${gpkgRelativePath}`;
     const jsonS3Key = gpkgS3Key.replace(/\.gpkg$/, '.json'); //TODO: In future, we will remove the json metadata file and support only gpkg
     const jsonPath = gpkgPath.replace(/\.gpkg$/, '.json'); //TODO: In future, we will remove the json metadata file and support only gpkg
@@ -357,11 +346,11 @@ export class ExportJobHandler extends JobHandler implements IJobHandler<ExportJo
     await this.queueClient.jobManagerClient.updateJob(job.id, { parameters: { ...job.parameters } });
   }
 
-  private async sendCallbacks(job: ExportJob, taskId: string, taskParams: ExportFinalizeTaskParams, dirPath: string): Promise<boolean> {
+  private async sendCallbacks(job: ExportJob, taskId: string, taskParams: ExportFinalizeTaskParams, dirPath: string): Promise<void> {
     try {
       const cleanupExpirationTimeUTC = createExpirationDate(this.cleanupExpirationDays);
       const cleanupDataParams: CleanupData = { cleanupExpirationTimeUTC, directoryPath: dirPath };
-      const callbackParams = this.createCallbacksParams(job, taskParams.status, cleanupExpirationTimeUTC);
+      const callbackParams = this.createCallbacksParams(job, cleanupExpirationTimeUTC);
 
       await this.queueClient.jobManagerClient.updateJob(job.id, {
         parameters: { ...job.parameters, cleanupDataParams, callbackParams },
@@ -370,11 +359,11 @@ export class ExportJobHandler extends JobHandler implements IJobHandler<ExportJo
       const targetCallbacks = job.parameters.exportInputParams.callbackUrls;
       // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
       if (!targetCallbacks?.length) {
-        this.logger.info({ msg: 'No callbacks url provided, skipping callbacks sending', jobId: job.id });
-        return false;
+        this.logger.warn({ msg: 'No callbacks url provided, skipping callbacks sending', jobId: job.id });
+        return;
       }
 
-      this.logger.info({ msg: 'Sending callbacks', jobId: job.id, status: taskParams.status, callbackCount: targetCallbacks.length });
+      this.logger.info({ msg: 'Sending callbacks', jobId: job.id, callbackCount: targetCallbacks.length });
 
       await Promise.all(
         targetCallbacks.map(async (callback) =>
@@ -390,28 +379,28 @@ export class ExportJobHandler extends JobHandler implements IJobHandler<ExportJo
         )
       );
 
-      const updatedParams = await this.markFinalizeStepAsCompleted(job.id, taskId, taskParams, 'callbacksSent');
-      return updatedParams.callbacksSent;
+      await this.markFinalizeStepAsCompleted(job.id, taskId, taskParams, 'callbacksSent');
     } catch (err) {
       this.logger.error({ msg: 'Sending callbacks has failed', err });
-      throw err;
     }
   }
 
-  private createCallbacksParams(job: ExportJob, status: CompletedOrFailedStatus, expirationDate: Date): CallbackExportResponse {
+  private createCallbacksParams(job: ExportJob, expirationDate: Date): CallbackExportResponse {
     const { additionalParams, callbackParams } = job.parameters;
     const { packageRelativePath, fileNamesTemplates } = additionalParams;
     const validCallbackParams = callbackExportResponseSchema.parse(callbackParams);
     const { jsonFileData, ...clientsCallbackParams } = validCallbackParams;
+
     const callbackResponse: CallbackExportResponse = {
       ...clientsCallbackParams,
-      status,
+      status: OperationStatus.FAILED,
       expirationTime: expirationDate,
       artifacts: [],
       links: undefined,
+      description: EXPORT_FAILURE_MESSAGE,
     };
 
-    if (status === OperationStatus.COMPLETED) {
+    if (job.status === OperationStatus.COMPLETED) {
       const gpkgDownloadUrl = this.isS3GpkgProvider
         ? `${this.downloadUrl}/${GPKGS_PREFIX}/${packageRelativePath}`
         : `${this.downloadUrl}/${packageRelativePath}`; //TODO: later when we change download server mount directory, the path for s3 and fs should be the same
@@ -434,8 +423,9 @@ export class ExportJobHandler extends JobHandler implements IJobHandler<ExportJo
         },
       ];
 
-      callbackResponse.links = { dataURI: gpkgDownloadUrl, metadataURI: jsonDownloadUrl };
+      callbackResponse.status = OperationStatus.COMPLETED;
       callbackResponse.description = EXPORT_SUCCESS_MESSAGE;
+      callbackResponse.links = { dataURI: gpkgDownloadUrl, metadataURI: jsonDownloadUrl };
     }
 
     return callbackResponse;

--- a/src/job/models/ingestion/newJobHandler.ts
+++ b/src/job/models/ingestion/newJobHandler.ts
@@ -8,7 +8,7 @@ import { lookup as mimeLookup } from '@map-colonies/types';
 import type { TilesMimeFormat } from '@map-colonies/types';
 import type { IngestionNewFinalizeTaskParams, NewRasterLayerMetadata, LayerNameFormats } from '@map-colonies/raster-shared';
 import { Grid } from '../../../common/interfaces';
-import type { IJobHandler, MergeTilesTaskParams, ExtendedRasterLayerMetadata } from '../../../common/interfaces';
+import type { IJobHandler, MergeTilesTaskParams, ExtendedRasterLayerMetadata, IConfig } from '../../../common/interfaces';
 import { TaskMetrics } from '../../../utils/metrics/taskMetrics';
 import { SERVICES } from '../../../common/constants';
 import type {
@@ -34,6 +34,7 @@ export class NewJobHandler
   /* eslint-enable @typescript-eslint/brace-style */
   public constructor(
     @inject(SERVICES.LOGGER) logger: Logger,
+    @inject(SERVICES.CONFIG) protected readonly config: IConfig,
     @inject(SERVICES.TRACER) public readonly tracer: Tracer,
     @inject(TileMergeTaskManager) private readonly taskBuilder: TileMergeTaskManager,
     @inject(SERVICES.QUEUE_CLIENT) queueClient: QueueClient,
@@ -43,7 +44,7 @@ export class NewJobHandler
     @inject(JobTrackerClient) jobTrackerClient: JobTrackerClient,
     private readonly taskMetrics: TaskMetrics
   ) {
-    super(logger, queueClient, jobTrackerClient);
+    super(logger, config, queueClient, jobTrackerClient);
   }
 
   public async handleJobInit(job: IngestionNewInitJob, task: IngestionInitTask): Promise<void> {

--- a/src/job/models/ingestion/swapJobHandler.ts
+++ b/src/job/models/ingestion/swapJobHandler.ts
@@ -5,7 +5,7 @@ import { context, trace } from '@opentelemetry/api';
 import type { Tracer } from '@opentelemetry/api';
 import { TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
 import type { IngestionSwapUpdateFinalizeTaskParams } from '@map-colonies/raster-shared';
-import type { IJobHandler, MergeTilesTaskParams } from '../../../common/interfaces';
+import type { IConfig, IJobHandler, MergeTilesTaskParams } from '../../../common/interfaces';
 import { Grid } from '../../../common/interfaces';
 import type {
   IngestionInitTask,
@@ -31,6 +31,8 @@ export class SwapJobHandler
   /* eslint-enable @typescript-eslint/brace-style */
   public constructor(
     @inject(SERVICES.LOGGER) logger: Logger,
+    @inject(SERVICES.CONFIG) protected readonly config: IConfig,
+
     @inject(SERVICES.TRACER) private readonly tracer: Tracer,
     @inject(SERVICES.QUEUE_CLIENT) protected queueClient: QueueClient,
     @inject(TileMergeTaskManager) private readonly taskBuilder: TileMergeTaskManager,
@@ -40,7 +42,7 @@ export class SwapJobHandler
     @inject(JobTrackerClient) jobTrackerClient: JobTrackerClient,
     private readonly taskMetrics: TaskMetrics
   ) {
-    super(logger, queueClient, jobTrackerClient);
+    super(logger, config, queueClient, jobTrackerClient);
   }
 
   public async handleJobInit(job: IngestionSwapUpdateInitJob, task: IngestionInitTask): Promise<void> {

--- a/src/job/models/ingestion/updateJobHandler.ts
+++ b/src/job/models/ingestion/updateJobHandler.ts
@@ -29,8 +29,8 @@ export class UpdateJobHandler
   /* eslint-enable @typescript-eslint/brace-style */
   public constructor(
     @inject(SERVICES.LOGGER) logger: Logger,
+    @inject(SERVICES.CONFIG) protected readonly config: IConfig,
     @inject(SERVICES.TRACER) public readonly tracer: Tracer,
-    @inject(SERVICES.CONFIG) private readonly config: IConfig,
     @inject(TileMergeTaskManager) private readonly taskBuilder: TileMergeTaskManager,
     @inject(SERVICES.QUEUE_CLIENT) protected queueClient: QueueClient,
     @inject(CatalogClient) private readonly catalogClient: CatalogClient,
@@ -38,7 +38,7 @@ export class UpdateJobHandler
     @inject(JobTrackerClient) jobTrackerClient: JobTrackerClient,
     private readonly taskMetrics: TaskMetrics
   ) {
-    super(logger, queueClient, jobTrackerClient);
+    super(logger, config, queueClient, jobTrackerClient);
   }
 
   public async handleJobInit(job: IngestionUpdateInitJob, task: IngestionInitTask): Promise<void> {

--- a/src/job/models/jobProcessor.ts
+++ b/src/job/models/jobProcessor.ts
@@ -120,7 +120,7 @@ export class JobProcessor {
             continue;
           }
 
-          const job = await this.getJob(task.jobId);
+          const job = await this.getJob(task.jobId, taskType);
           this.logger.info({ msg: `got job and task response`, jobId: job.id, jobType: job.type, taskId: task.id, taskType: task.type });
 
           return { job, task };
@@ -134,13 +134,17 @@ export class JobProcessor {
     }
   }
 
-  private async getJob(jobId: string): Promise<IJobResponse<unknown, unknown>> {
+  private async getJob(jobId: string, taskType: string): Promise<IJobResponse<unknown, unknown>> {
     const logger = this.logger.child({ jobId });
 
     logger.info({ msg: `updating job status to ${OperationStatus.IN_PROGRESS}` });
-    await this.queueClient.jobManagerClient.updateJob(jobId, { status: OperationStatus.IN_PROGRESS });
 
     const job = await this.queueClient.jobManagerClient.getJob(jobId);
+
+    if (taskType === this.pollingConfig.tasks.init) {
+      await this.queueClient.jobManagerClient.updateJob(jobId, { status: OperationStatus.IN_PROGRESS });
+    }
+
     logger.info({ msg: `got job ${job.id}`, jobType: job.type });
 
     return job;

--- a/src/utils/zod/schemas/job.schema.ts
+++ b/src/utils/zod/schemas/job.schema.ts
@@ -69,7 +69,7 @@ export type IngestionSwapUpdateFinalizeTask = z.infer<typeof ingestionSwapUpdate
 //#endregion
 
 //#region Export
-export const exportJobSchema = createJobResponseSchema(exportJobParametersSchema).describe('ExportJobSchema');
+export const exportJobSchema = createJobResponseSchema(exportJobParametersSchema.passthrough()).describe('ExportJobSchema');
 export type ExportJob = z.infer<typeof exportJobSchema>;
 
 //init
@@ -80,8 +80,6 @@ export type ExportInitTask = z.infer<typeof exportInitTaskSchema>;
 export const exportFinalizeTaskSchema = createTaskResponseSchema(exportFinalizeTaskParamsSchema).describe('ExportFinalizeTaskSchema');
 export type ExportFinalizeTask = z.infer<typeof exportFinalizeTaskSchema>;
 export type ExportFinalizeTaskParams = z.infer<typeof exportFinalizeTaskParamsSchema>;
-export type ExportFinalizeSuccessTaskParams = Extract<ExportFinalizeTaskParams, { status: OperationStatus.COMPLETED }>;
-export type ExportFinalizeFailureTaskParams = Extract<ExportFinalizeTaskParams, { status: OperationStatus.FAILED }>;
 //#endregion
 
 export type OperationValidationKey = `${JobTypes}_${TaskTypes}`;

--- a/src/utils/zod/schemas/job.schema.ts
+++ b/src/utils/zod/schemas/job.schema.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { z } from 'zod';
-import { OperationStatus } from '@map-colonies/mc-priority-queue';
 import {
   createJobResponseSchema,
   createTaskResponseSchema,

--- a/tests/unit/job/jobHnadler/jobHandler.spec.ts
+++ b/tests/unit/job/jobHnadler/jobHandler.spec.ts
@@ -1,5 +1,6 @@
 import { ZodError } from 'zod';
 import { JobAndTaskTelemetry } from '../../../../src/common/interfaces';
+import { registerDefaultConfig } from '../../mocks/configMock';
 import { ingestionNewJob } from '../../mocks/jobsMockData';
 import { initTaskForIngestionNew } from '../../mocks/tasksMockData';
 import { setupJobHandlerTest } from './jobHandlerSetup';
@@ -7,6 +8,7 @@ import { setupJobHandlerTest } from './jobHandlerSetup';
 describe('JobHandler', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    registerDefaultConfig();
   });
 
   describe('handleError', () => {

--- a/tests/unit/job/jobHnadler/jobHandlerSetup.ts
+++ b/tests/unit/job/jobHnadler/jobHandlerSetup.ts
@@ -3,6 +3,7 @@ import { TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
 import { jobTrackerClientMock, queueClientMock } from '../../mocks/jobManagerMocks';
 import { JobHandler } from '../../../../src/job/models/jobHandler';
 import { JobTrackerClient } from '../../../../src/httpClients/jobTrackerClient';
+import { configMock } from '../../mocks/configMock';
 
 export interface JobHandlerTestContext {
   newJobHandler: JobHandler;
@@ -11,7 +12,7 @@ export interface JobHandlerTestContext {
 }
 
 export const setupJobHandlerTest = (): JobHandlerTestContext => {
-  const newJobHandler = new JobHandler(jsLogger({ enabled: false }), queueClientMock, jobTrackerClientMock);
+  const newJobHandler = new JobHandler(jsLogger({ enabled: false }), configMock, queueClientMock, jobTrackerClientMock);
 
   return {
     newJobHandler,

--- a/tests/unit/job/newJobHandler/newJobHandler.spec.ts
+++ b/tests/unit/job/newJobHandler/newJobHandler.spec.ts
@@ -3,12 +3,14 @@
 import { finalizeTaskForIngestionNew, initTaskForIngestionNew } from '../../mocks/tasksMockData';
 import { ingestionNewJob, ingestionNewJobExtended } from '../../mocks/jobsMockData';
 import { MergeTaskParameters } from '../../../../src/common/interfaces';
+import { registerDefaultConfig } from '../../mocks/configMock';
 import { PublishLayerError } from '../../../../src/common/errors';
 import { setupNewJobHandlerTest } from './newJobHandlerSetup';
 
 describe('NewJobHandler', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    registerDefaultConfig();
   });
   describe('handleJobInit', () => {
     it('should handle job init successfully', async () => {

--- a/tests/unit/job/newJobHandler/newJobHandlerSetup.ts
+++ b/tests/unit/job/newJobHandler/newJobHandlerSetup.ts
@@ -9,6 +9,7 @@ import { taskMetricsMock } from '../../mocks/metricsMock';
 import { jobManagerClientMock, jobTrackerClientMock, queueClientMock } from '../../mocks/jobManagerMocks';
 import { tracerMock } from '../../mocks/tracerMock';
 import { JobTrackerClient } from '../../../../src/httpClients/jobTrackerClient';
+import { configMock } from '../../mocks/configMock';
 
 export interface NewJobHandlerTestContext {
   newJobHandler: NewJobHandler;
@@ -33,6 +34,7 @@ export const setupNewJobHandlerTest = (): NewJobHandlerTestContext => {
 
   const newJobHandler = new NewJobHandler(
     jsLogger({ enabled: false }),
+    configMock,
     tracerMock,
     taskBuilderMock,
     queueClientMock,

--- a/tests/unit/job/swapJobHandler/swapJobHandlerSetup.ts
+++ b/tests/unit/job/swapJobHandler/swapJobHandlerSetup.ts
@@ -9,6 +9,7 @@ import { taskMetricsMock } from '../../mocks/metricsMock';
 import { jobManagerClientMock, jobTrackerClientMock, queueClientMock } from '../../mocks/jobManagerMocks';
 import { tracerMock } from '../../mocks/tracerMock';
 import { JobTrackerClient } from '../../../../src/httpClients/jobTrackerClient';
+import { configMock } from '../../mocks/configMock';
 
 export interface SwapJobHandlerTestContext {
   swapJobHandler: SwapJobHandler;
@@ -33,6 +34,7 @@ export const setupSwapJobHandlerTest = (): SwapJobHandlerTestContext => {
 
   const swapJobHandler = new SwapJobHandler(
     jsLogger({ enabled: false }),
+    configMock,
     tracerMock,
     queueClientMock,
     taskBuilderMock,

--- a/tests/unit/job/updateJobHandler/updateJobHandlerSetup.ts
+++ b/tests/unit/job/updateJobHandler/updateJobHandlerSetup.ts
@@ -34,8 +34,8 @@ export const setupUpdateJobHandlerTest = (): UpdateJobHandlerTestContext => {
   const seedingJobCreatorMock = { create: jest.fn() } as unknown as jest.Mocked<SeedingJobCreator>;
   const updateJobHandler = new UpdateJobHandler(
     jsLogger({ enabled: false }),
-    tracerMock,
     configMock,
+    tracerMock,
     taskBuilderMock,
     queueClientMock,
     catalogClientMock,

--- a/tests/unit/mocks/jobManagerMocks.ts
+++ b/tests/unit/mocks/jobManagerMocks.ts
@@ -5,6 +5,7 @@ export const jobManagerClientMock = {
   updateJob: jest.fn(),
   updateTask: jest.fn(),
   createTaskForJob: jest.fn(),
+  getJob: jest.fn(),
 } as unknown as jest.Mocked<JobManagerClient>;
 
 export const queueClientMock = {

--- a/tests/unit/mocks/tasksMockData.ts
+++ b/tests/unit/mocks/tasksMockData.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import {
+  ExportFinalizeType,
   IngestionNewFinalizeTaskParams,
   IngestionSwapUpdateFinalizeTaskParams,
   IngestionUpdateFinalizeTaskParams,
@@ -84,7 +85,7 @@ export const finalizeTaskForExport: ExportFinalizeTask = {
   type: 'finalize',
   description: '',
   parameters: {
-    status: OperationStatus.COMPLETED,
+    type: ExportFinalizeType.Full_Processing,
     gpkgModified: false,
     gpkgUploadedToS3: false,
     callbacksSent: false,
@@ -108,27 +109,9 @@ export const finalizeSuccessTaskForExport: ExportFinalizeTask = {
   percentage: 100,
   reason: '',
   parameters: {
-    status: OperationStatus.COMPLETED,
+    type: ExportFinalizeType.Full_Processing,
     gpkgModified: false,
     gpkgUploadedToS3: false,
-    callbacksSent: false,
-  },
-  attempts: 0,
-  resettable: false,
-  created: '2023-01-01T00:00:00.000Z',
-  updated: '2023-01-01T00:00:00.000Z',
-};
-
-export const finalizeFailureTaskForExport: ExportFinalizeTask = {
-  id: '04f01850-9e67-4fac-bc01-f9b416f801bf',
-  jobId: '8e8b03fa-e0cf-4d93-9034-709007da818a',
-  type: 'finalize',
-  description: '',
-  status: OperationStatus.IN_PROGRESS,
-  percentage: 100,
-  reason: '',
-  parameters: {
-    status: OperationStatus.FAILED,
     callbacksSent: false,
   },
   attempts: 0,


### PR DESCRIPTION
<!--
Make sure you've read the contributing guidelines (CONTRIBUTING.md)
-->

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✔                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

Further  information:
This PR refactors the `handleJobFinalize` method in the Export Job Handler to improve code organization, maintainability, and readability. The changes include replacing nested if-statements with a switch-case structure and extracting processing logic into dedicated methods with a cleaner context-passing pattern. Additionally, we've added support for proper handling of `FullProcessing` and `ErrorCallback` task types.

## Changes
- Replaced if-statements with a switch-case to handle different task types (`ExportFinalizeType`)
- Extracted full processing logic into a separate `handleFullProcessing` method
- Added proper handling for `FullProcessing` and `ErrorCallback` task types
- Introduced a `JobExecutionContext` interface to centralize execution state
- Added a helper method `createExecutionContext` to initialize and organize dependencies
- Improved organization of related data (paths, monitoring, etc.)



