### PR TITLE
fix: filter conflicted geometry (MAPCO-10674)

### DIFF
--- a/src/task/models/deletionTaskManager.ts
+++ b/src/task/models/deletionTaskManager.ts
@@ -159,7 +159,8 @@ export class TileDeletionTaskManager {
       const conflictGeometries = conflictFeatures
         .filter((feature) => feature.properties?.e_res != null)
         .map((feature) => turfFeature(feature.geometry as Polygon | MultiPolygon));
-      logger.info({ msg: 'Union conflict features into single geometry' });
+
+      logger.info({ msg: 'Unioning conflict features into single geometry', conflictFeatureCount: conflictGeometries.length });
       const unionedConflictGeometry = conflictGeometries.length === 1 ? conflictGeometries[0] : union(turfFeatureCollection(conflictGeometries));
 
       if (unionedConflictGeometry === null) {

--- a/src/task/models/deletionTaskManager.ts
+++ b/src/task/models/deletionTaskManager.ts
@@ -156,7 +156,9 @@ export class TileDeletionTaskManager {
       logger.info({ msg: 'Conflict features read from report', featureCount: conflictFeatures.length });
 
       // 2. Union all conflict geometries into one entity
-      const conflictGeometries = conflictFeatures.map((f) => turfFeature(f.geometry as Polygon | MultiPolygon));
+      const conflictGeometries = conflictFeatures
+        .filter((feature) => feature.properties?.e_res != null)
+        .map((feature) => turfFeature(feature.geometry as Polygon | MultiPolygon));
       logger.info({ msg: 'Union conflict features into single geometry' });
       const unionedConflictGeometry = conflictGeometries.length === 1 ? conflictGeometries[0] : union(turfFeatureCollection(conflictGeometries));
 

--- a/tests/unit/mocks/tasksMockData.ts
+++ b/tests/unit/mocks/tasksMockData.ts
@@ -83,7 +83,7 @@ export const validationTaskForIngestionUpdate = createFakeTask<IngestionValidati
   { checksums: [] }
 );
 
-export const validationTaskWithResolutionErrorsAndReport = createFakeTask<IngestionValidationTaskParams>(
+export const validationTaskWithResolutionErrors = createFakeTask<IngestionValidationTaskParams>(
   { jobId: ingestionUpdateJob.id, type: 'validation' },
   {
     checksums: [],

--- a/tests/unit/mocks/tasksMockData.ts
+++ b/tests/unit/mocks/tasksMockData.ts
@@ -113,6 +113,36 @@ export const validationTaskWithResolutionErrorsAndReport = createFakeTask<Ingest
   }
 );
 
+export const validationTaskWithResolutionAndSmallHolesErrorsAndReport = createFakeTask<IngestionValidationTaskParams>(
+  { jobId: ingestionUpdateJob.id, type: 'validation' },
+  {
+    checksums: [],
+    isValid: false,
+    report: {
+      fileName: 'report.zip',
+      fileSize: 2048,
+      url: 'http://report-server/report.zip',
+      path: '/reports/report.zip',
+    },
+    errorsSummary: {
+      errorsCount: {
+        geometryValidity: 0,
+        vertices: 0,
+        metadata: 0,
+        resolution: 19,
+        smallHoles: 1,
+        smallGeometries: 0,
+        unknown: 0,
+      },
+      thresholds: {
+        resolution: { exceeded: false },
+        smallHoles: { exceeded: false, count: 3 },
+        smallGeometries: { exceeded: false },
+      },
+    },
+  }
+);
+
 export const validationTaskWithResolutionErrorsNoReportUrl = createFakeTask<IngestionValidationTaskParams>(
   { jobId: ingestionUpdateJob.id, type: 'validation' },
   {

--- a/tests/unit/task/tileDeletionTaskManager/tileDeletionTaskManager.spec.ts
+++ b/tests/unit/task/tileDeletionTaskManager/tileDeletionTaskManager.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { NotFoundError } from '@map-colonies/error-types';
 import { TaskBlockDuplicationParam } from '@map-colonies/raster-shared';
+import { Polygon } from 'geojson';
 import { configMock, registerDefaultConfig } from '../../mocks/configMock';
 import { ingestionUpdateJob } from '../../mocks/jobsMockData';
 import {
@@ -14,7 +15,6 @@ import { IngestionCreateTasksTask } from '../../../../src/utils/zod/schemas/job.
 import { jobManagerClientMock } from '../../mocks/jobManagerMocks';
 import * as reportUtils from '../../../../src/utils/report';
 import { polygonPartsMangerClientMock, setupTileDeletionTaskManagerTest, type TileDeletionTaskManagerContext } from './tileDeletionTaskManagerSetup';
-import { Polygon } from 'geojson';
 
 describe('TileDeletionTaskManager', () => {
   let testContext: TileDeletionTaskManagerContext;

--- a/tests/unit/task/tileDeletionTaskManager/tileDeletionTaskManager.spec.ts
+++ b/tests/unit/task/tileDeletionTaskManager/tileDeletionTaskManager.spec.ts
@@ -7,13 +7,14 @@ import {
   createFakeTask,
   validationTaskForIngestionUpdate,
   validationTaskWithResolutionAndSmallHolesErrorsAndReport,
-  validationTaskWithResolutionErrorsAndReport,
+  validationTaskWithResolutionErrors,
   validationTaskWithResolutionErrorsNoReportUrl,
 } from '../../mocks/tasksMockData';
 import { IngestionCreateTasksTask } from '../../../../src/utils/zod/schemas/job.schema';
 import { jobManagerClientMock } from '../../mocks/jobManagerMocks';
 import * as reportUtils from '../../../../src/utils/report';
 import { polygonPartsMangerClientMock, setupTileDeletionTaskManagerTest, type TileDeletionTaskManagerContext } from './tileDeletionTaskManagerSetup';
+import { Polygon } from 'geojson';
 
 describe('TileDeletionTaskManager', () => {
   let testContext: TileDeletionTaskManagerContext;
@@ -80,7 +81,7 @@ describe('TileDeletionTaskManager', () => {
     it('should call buildTasks and pushTasks when resolution errors exist and report URL is present', async () => {
       const { tileDeletionTaskManager } = testContext;
 
-      jobManagerClientMock.findTasks.mockResolvedValue([validationTaskWithResolutionErrorsAndReport]);
+      jobManagerClientMock.findTasks.mockResolvedValue([validationTaskWithResolutionErrors]);
 
       const buildTasksSpy = jest.spyOn(tileDeletionTaskManager, 'buildTasks');
       const pushTasksSpy = jest.spyOn(tileDeletionTaskManager, 'pushTasks').mockResolvedValue(undefined);
@@ -94,7 +95,7 @@ describe('TileDeletionTaskManager', () => {
           layerRelativePath,
           ingestionResolution: ingestionUpdateJob.parameters.ingestionResolution,
           tileOutputFormat: ingestionUpdateJob.parameters.additionalParams.tileOutputFormat,
-          reportUrl: validationTaskWithResolutionErrorsAndReport.parameters.report?.url,
+          reportUrl: validationTaskWithResolutionErrors.parameters.report?.url,
         })
       );
       expect(pushTasksSpy).toHaveBeenCalledWith(ingestionUpdateJob.id, ingestionUpdateJob.type, expect.anything());
@@ -103,7 +104,7 @@ describe('TileDeletionTaskManager', () => {
     it('should propagate non-NotFoundError thrown by pushTasks', async () => {
       const { tileDeletionTaskManager } = testContext;
 
-      jobManagerClientMock.findTasks.mockResolvedValue([validationTaskWithResolutionErrorsAndReport]);
+      jobManagerClientMock.findTasks.mockResolvedValue([validationTaskWithResolutionErrors]);
       jest.spyOn(tileDeletionTaskManager, 'buildTasks');
       jest.spyOn(tileDeletionTaskManager, 'pushTasks').mockRejectedValue(new Error('unexpected push failure'));
 
@@ -116,8 +117,8 @@ describe('TileDeletionTaskManager', () => {
       const { tileDeletionTaskManager } = testContext;
 
       // polygon A – the resolution conflict geometry (e_res), should drive deletion task generation
-      const eResGeometry = {
-        type: 'Polygon' as const,
+      const eResGeometry: Polygon = {
+        type: 'Polygon',
         coordinates: [
           [
             [0, 0],
@@ -129,8 +130,8 @@ describe('TileDeletionTaskManager', () => {
         ],
       };
       // polygon B – a small-holes conflict geometry (e_sm_holes), must NOT be used
-      const eSmHolesGeometry = {
-        type: 'Polygon' as const,
+      const eSmHolesGeometry: Polygon = {
+        type: 'Polygon',
         coordinates: [
           [
             [10, 10],
@@ -180,7 +181,7 @@ describe('TileDeletionTaskManager', () => {
     it('should NOT swallow a NotFoundError thrown by pushTasks - only pre-try NotFoundErrors are swallowed', async () => {
       const { tileDeletionTaskManager } = testContext;
 
-      jobManagerClientMock.findTasks.mockResolvedValue([validationTaskWithResolutionErrorsAndReport]);
+      jobManagerClientMock.findTasks.mockResolvedValue([validationTaskWithResolutionErrors]);
       jest.spyOn(tileDeletionTaskManager, 'buildTasks');
       // pushTasks is inside the try block, so a NotFoundError it throws IS caught and swallowed
       jest.spyOn(tileDeletionTaskManager, 'pushTasks').mockRejectedValue(new NotFoundError('from pushTasks'));
@@ -212,7 +213,7 @@ describe('TileDeletionTaskManager', () => {
       const { tileDeletionTaskManager } = testContext;
 
       // First task has no resolution errors, second has — only first should be used
-      jobManagerClientMock.findTasks.mockResolvedValue([validationTaskForIngestionUpdate, validationTaskWithResolutionErrorsAndReport]);
+      jobManagerClientMock.findTasks.mockResolvedValue([validationTaskForIngestionUpdate, validationTaskWithResolutionErrors]);
       jest.spyOn(tileDeletionTaskManager, 'pushTasks').mockResolvedValue(undefined);
 
       await tileDeletionTaskManager.buildAndPushTasks(ingestionUpdateJob, task, polygonPartsEntityName, layerRelativePath);

--- a/tests/unit/task/tileDeletionTaskManager/tileDeletionTaskManager.spec.ts
+++ b/tests/unit/task/tileDeletionTaskManager/tileDeletionTaskManager.spec.ts
@@ -12,8 +12,8 @@ import {
 } from '../../mocks/tasksMockData';
 import { IngestionCreateTasksTask } from '../../../../src/utils/zod/schemas/job.schema';
 import { jobManagerClientMock } from '../../mocks/jobManagerMocks';
-import { polygonPartsMangerClientMock, setupTileDeletionTaskManagerTest, type TileDeletionTaskManagerContext } from './tileDeletionTaskManagerSetup';
 import * as reportUtils from '../../../../src/utils/report';
+import { polygonPartsMangerClientMock, setupTileDeletionTaskManagerTest, type TileDeletionTaskManagerContext } from './tileDeletionTaskManagerSetup';
 
 describe('TileDeletionTaskManager', () => {
   let testContext: TileDeletionTaskManagerContext;
@@ -118,16 +118,34 @@ describe('TileDeletionTaskManager', () => {
       // polygon A – the resolution conflict geometry (e_res), should drive deletion task generation
       const eResGeometry = {
         type: 'Polygon' as const,
-        coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+        coordinates: [
+          [
+            [0, 0],
+            [1, 0],
+            [1, 1],
+            [0, 1],
+            [0, 0],
+          ],
+        ],
       };
       // polygon B – a small-holes conflict geometry (e_sm_holes), must NOT be used
       const eSmHolesGeometry = {
         type: 'Polygon' as const,
-        coordinates: [[[10, 10], [11, 10], [11, 11], [10, 11], [10, 10]]],
+        coordinates: [
+          [
+            [10, 10],
+            [11, 10],
+            [11, 11],
+            [10, 11],
+            [10, 10],
+          ],
+        ],
       };
 
       jest.spyOn(reportUtils, 'readConflictFeatures').mockResolvedValue([
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         { type: 'Feature', geometry: eResGeometry, properties: { e_res: 'Resolution Conflict' } },
+        // eslint-disable-next-line @typescript-eslint/naming-convention
         { type: 'Feature', geometry: eSmHolesGeometry, properties: { e_sm_holes: 'Contains small holes' } },
       ]);
 
@@ -141,6 +159,7 @@ describe('TileDeletionTaskManager', () => {
       expect(polygonPartsMangerClientMock.getIntersection).toHaveBeenCalledWith(
         polygonPartsEntityName,
         expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           features: expect.arrayContaining([expect.objectContaining({ geometry: eResGeometry })]),
         })
       );
@@ -149,6 +168,7 @@ describe('TileDeletionTaskManager', () => {
       expect(polygonPartsMangerClientMock.getIntersection).not.toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           features: expect.arrayContaining([expect.objectContaining({ geometry: eSmHolesGeometry })]),
         })
       );

--- a/tests/unit/task/tileDeletionTaskManager/tileDeletionTaskManager.spec.ts
+++ b/tests/unit/task/tileDeletionTaskManager/tileDeletionTaskManager.spec.ts
@@ -6,12 +6,14 @@ import { ingestionUpdateJob } from '../../mocks/jobsMockData';
 import {
   createFakeTask,
   validationTaskForIngestionUpdate,
+  validationTaskWithResolutionAndSmallHolesErrorsAndReport,
   validationTaskWithResolutionErrorsAndReport,
   validationTaskWithResolutionErrorsNoReportUrl,
 } from '../../mocks/tasksMockData';
 import { IngestionCreateTasksTask } from '../../../../src/utils/zod/schemas/job.schema';
 import { jobManagerClientMock } from '../../mocks/jobManagerMocks';
-import { setupTileDeletionTaskManagerTest, type TileDeletionTaskManagerContext } from './tileDeletionTaskManagerSetup';
+import { polygonPartsMangerClientMock, setupTileDeletionTaskManagerTest, type TileDeletionTaskManagerContext } from './tileDeletionTaskManagerSetup';
+import * as reportUtils from '../../../../src/utils/report';
 
 describe('TileDeletionTaskManager', () => {
   let testContext: TileDeletionTaskManagerContext;
@@ -108,6 +110,51 @@ describe('TileDeletionTaskManager', () => {
       await expect(tileDeletionTaskManager.buildAndPushTasks(ingestionUpdateJob, task, polygonPartsEntityName, layerRelativePath)).rejects.toThrow(
         'unexpected push failure'
       );
+    });
+
+    it('should not build deletion tasks for non-resolution conflict features (e.g. e_sm_holes) present in the report', async () => {
+      const { tileDeletionTaskManager } = testContext;
+
+      // polygon A – the resolution conflict geometry (e_res), should drive deletion task generation
+      const eResGeometry = {
+        type: 'Polygon' as const,
+        coordinates: [[[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]],
+      };
+      // polygon B – a small-holes conflict geometry (e_sm_holes), must NOT be used
+      const eSmHolesGeometry = {
+        type: 'Polygon' as const,
+        coordinates: [[[10, 10], [11, 10], [11, 11], [10, 11], [10, 10]]],
+      };
+
+      jest.spyOn(reportUtils, 'readConflictFeatures').mockResolvedValue([
+        { type: 'Feature', geometry: eResGeometry, properties: { e_res: 'Resolution Conflict' } },
+        { type: 'Feature', geometry: eSmHolesGeometry, properties: { e_sm_holes: 'Contains small holes' } },
+      ]);
+
+      jobManagerClientMock.findTasks.mockResolvedValue([validationTaskWithResolutionAndSmallHolesErrorsAndReport]);
+      // return empty intersection so no actual tile batches are generated
+      polygonPartsMangerClientMock.getIntersection.mockResolvedValue({ type: 'FeatureCollection', features: [] });
+
+      await tileDeletionTaskManager.buildAndPushTasks(ingestionUpdateJob, task, polygonPartsEntityName, layerRelativePath);
+
+      // getIntersection must have been called with a payload containing the e_res geometry
+      expect(polygonPartsMangerClientMock.getIntersection).toHaveBeenCalledWith(
+        polygonPartsEntityName,
+        expect.objectContaining({
+          features: expect.arrayContaining([expect.objectContaining({ geometry: eResGeometry })]),
+        })
+      );
+
+      // getIntersection must NOT have been called with a payload containing the e_sm_holes geometry
+      expect(polygonPartsMangerClientMock.getIntersection).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          features: expect.arrayContaining([expect.objectContaining({ geometry: eSmHolesGeometry })]),
+        })
+      );
+
+      // intersection was empty → no deletion task batches should have been enqueued
+      expect(jobManagerClientMock.createTaskForJob).not.toHaveBeenCalled();
     });
 
     it('should NOT swallow a NotFoundError thrown by pushTasks - only pre-try NotFoundErrors are swallowed', async () => {


### PR DESCRIPTION

This pull request improves how the `TileDeletionTaskManager` processes conflict features from validation reports, ensuring only relevant conflicts (specifically, resolution conflicts) are used to generate deletion tasks. It also adds new test data and test cases to verify this behavior.

**Core logic improvements:**

* The conflict feature filtering logic in `TileDeletionTaskManager` was updated to include only features with the `e_res` property (resolution conflicts) when building deletion tasks, ignoring other conflict types such as small holes. This ensures deletion tasks are generated only for the intended conflict type.

**Testing improvements:**

* A new mock validation task, `validationTaskWithResolutionAndSmallHolesErrorsAndReport`, was added to provide test data that includes both resolution and small-holes errors.
* A new test case was added to verify that only resolution conflict features drive deletion task generation, and that features with other conflict types (like small holes) are ignored. The test checks that only the relevant geometry is passed to the intersection logic and that no deletion tasks are enqueued if there are no intersecting tiles.
* The test setup was updated to import the new mock data and utilities required for the new test case.

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✔                                                                        |
| Chore            | ✖                                                                       |

Related issues: #MAPCO-10674