### PR TITLE
feat: full layer deletion flow (MAPCO-7285)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,12 @@ dist
 #helm
 Chart.lock
 
+.claude
+.claude-flow
+.swarm
+.mcp.json
+CLAUDE.md
+/ai-docs
+# ruflo / claude-flow vector memory store
+ruvector.db
+/docs

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -67,7 +67,8 @@
     "accessKeyId": "S3_ACCESS_KEY_ID",
     "secretAccessKey": "S3_SECRET_ACCESS_KEY",
     "endpointUrl": "S3_ENDPOINT_URL",
-    "bucket": "S3_ARTIFACTS_BUCKET",
+    "artifactsBucket": "S3_ARTIFACTS_BUCKET",
+    "tilesBucket": "S3_TILES_BUCKET",
     "sslEnabled": {
       "__name": "S3_SSL_ENABLED",
       "__format": "boolean"

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -125,7 +125,8 @@
       "tasks": {
         "createTasks": "POLLING_CREATE_TASKS_TASK",
         "finalize": "POLLING_FINALIZE_TASK",
-        "init": "POLLING_INIT_TASK"
+        "init": "POLLING_INIT_TASK",
+        "delete": "POLLING_DELETE_TASK"
       }
     },
     "ingestion": {
@@ -138,6 +139,9 @@
         },
         "swapUpdate": {
           "type": "INGESTION_SWAP_UPDATE_JOB_TYPE"
+        },
+        "deleteLayer": {
+          "type": "INGESTION_DELETE_LAYER_JOB_TYPE"
         }
       },
       "jobs": {

--- a/config/default.json
+++ b/config/default.json
@@ -92,7 +92,8 @@
       "tasks": {
         "createTasks": "create-tasks",
         "init": "init",
-        "finalize": "finalize"
+        "finalize": "finalize",
+        "delete": "delete"
       }
     },
     "ingestion": {
@@ -105,6 +106,9 @@
         },
         "swapUpdate": {
           "type": "Ingestion_Swap_Update"
+        },
+        "deleteLayer": {
+          "type": "Delete_Layer"
         }
       },
       "jobs": {

--- a/config/default.json
+++ b/config/default.json
@@ -48,7 +48,8 @@
     "accessKeyId": "minioadmin",
     "secretAccessKey": "minioadmin",
     "endpointUrl": "http://localhost:9000",
-    "bucket": "",
+    "artifactsBucket": "",
+    "tilesBucket": "",
     "sslEnabled": false
   },
   "disableHttpClientLogs": true,

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -52,9 +52,11 @@ data:
   POLLING_CREATE_TASKS_TASK: {{ $jobDefinitions.tasks.createTasks.type | quote }}
   POLLING_INIT_TASK: {{ $jobDefinitions.tasks.init.type | quote }}
   POLLING_FINALIZE_TASK: {{ $jobDefinitions.tasks.finalize.type | quote }}
+  POLLING_DELETE_TASK: {{ $jobDefinitions.tasks.delete.type | quote }}
   INGESTION_NEW_JOB_TYPE: {{ $jobDefinitions.jobs.new.type | quote }}
   INGESTION_UPDATE_JOB_TYPE: {{ $jobDefinitions.jobs.update.type | quote }}
   INGESTION_SWAP_UPDATE_JOB_TYPE: {{ $jobDefinitions.jobs.swapUpdate.type | quote }}
+  INGESTION_DELETE_LAYER_JOB_TYPE: {{ $jobDefinitions.jobs.deleteLayer.type | quote }}
   INGESTION_SEED_JOB_TYPE : {{ $jobDefinitions.jobs.seed.type | quote }}
   EXPORT_JOB_TYPE: {{ $jobDefinitions.jobs.export.type | quote }}
   EXPORT_CLEANUP_EXPIRATION_DAYS: {{ $jobDefinitions.jobs.export.cleanupExpirationDays | quote }}

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -33,6 +33,9 @@ data:
   S3_ARTIFACTS_BUCKET: {{ $storage.s3.artifactsBucket | quote }}
   S3_SSL_ENABLED: {{ $storage.s3.sslEnabled | quote }}
   {{- end }}
+  {{- if eq (upper $storage.tilesStorageProvider) "S3" }}
+  S3_TILES_BUCKET: {{ $storage.s3.tilesBucket | quote }}
+  {{- end }}
   npm_config_cache: /tmp/
 
   HTTP_RETRY_ATTEMPTS: {{ .Values.env.httpRetry.attempts | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -87,6 +87,7 @@ storage:
   s3:
     endpointUrl: ""
     artifactsBucket: ""
+    tilesBucket: ""
     sslEnabled: false
     secretName: ""
   fs:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -138,6 +138,8 @@ jobDefinitions:
       type: ""
     swapUpdate:
       type: ""
+    deleteLayer:
+      type: ""
     seed:
       type: ""
     export:
@@ -150,6 +152,8 @@ jobDefinitions:
     init:
       type: ""
     finalize:
+      type: ""
+    delete:
       type: ""
     merge:
       type: ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@map-colonies/mc-priority-queue": "^9.1.2",
         "@map-colonies/mc-utils": "^6.0.1",
         "@map-colonies/prometheus": "^1.0.0",
-        "@map-colonies/raster-shared": "^8.3.0-alpha.0",
+        "@map-colonies/raster-shared": "^8.3.0-alpha.1",
         "@map-colonies/read-pkg": "^1.0.0",
         "@map-colonies/schemas": "^1.18.0",
         "@map-colonies/shapefile-reader": "^1.0.1",
@@ -6593,9 +6593,9 @@
       }
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "8.3.0-alpha.0",
-      "resolved": "file:../../../../../repositories/raster-shared/map-colonies-raster-shared-8.3.0-alpha.0.tgz",
-      "integrity": "sha512-6uNe470hR6+3fnMQ04ZSAZxfOAzAU9HYp28gkhiAoucEHLYx5Anp37hhRxJfG4U2pQjr2Ypj/S8tDCftQKD7xQ==",
+      "version": "8.3.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.3.0-alpha.1.tgz",
+      "integrity": "sha512-KP/n3ZPcG7ULHrtX3h9fMOTNnF5Qkos1N9ZPjawi/5yiDHit9S5V9sFI4Tgv5aMchgSS0zXu5gL0ybA4/CliYQ==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^9.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@map-colonies/mc-priority-queue": "^9.1.2",
         "@map-colonies/mc-utils": "^6.0.1",
         "@map-colonies/prometheus": "^1.0.0",
-        "@map-colonies/raster-shared": "^8.1.0",
+        "@map-colonies/raster-shared": "^8.3.0-alpha.0",
         "@map-colonies/read-pkg": "^1.0.0",
         "@map-colonies/schemas": "^1.18.0",
         "@map-colonies/shapefile-reader": "^1.0.1",
@@ -6593,9 +6593,9 @@
       }
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.1.0.tgz",
-      "integrity": "sha512-D/otgsJ7X00NnxlMJUSuj6rC9U779ReZDe4pAmtGsIOuQvASRnjjKIGIj/9nFJth6lbOaptppp0RRGImGd0jIw==",
+      "version": "8.3.0-alpha.0",
+      "resolved": "file:../../../../../repositories/raster-shared/map-colonies-raster-shared-8.3.0-alpha.0.tgz",
+      "integrity": "sha512-6uNe470hR6+3fnMQ04ZSAZxfOAzAU9HYp28gkhiAoucEHLYx5Anp37hhRxJfG4U2pQjr2Ypj/S8tDCftQKD7xQ==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^9.1.0",
@@ -16426,18 +16426,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/conventional-commits-filter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/conventional-commits-parser": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
@@ -17710,38 +17698,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/eslint-plugin-jest": {
-      "version": "29.15.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
-      "integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@typescript-eslint/utils": "^8.0.0"
-      },
-      "engines": {
-        "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^8.0.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "jest": "*",
-        "typescript": ">=4.8.4 <7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@typescript-eslint/eslint-plugin": {
-          "optional": true
-        },
-        "jest": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/eslint-plugin-unicorn": {
@@ -19277,21 +19233,6 @@
       },
       "bin": {
         "which": "bin/which"
-      }
-    },
-    "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/globby": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7313,8 +7313,8 @@
       "version": "0.57.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.57.1.tgz",
       "integrity": "sha512-r+ulPbvgG8rGgFFWbJWJpTh7nMzsEYH7rBFNWdFs7ZfVAtgpFijMkRtU7DecIo6ItF8Op+RxogSuk/083W8HKw==",
-      "license": "Apache-2.0",nch 
-      "dependencies": {nch 
+      "license": "Apache-2.0",
+      "dependencies": {
         "@opentelemetry/core": "^2.0.0",
         "@opentelemetry/instrumentation": "^0.208.0",
         "@opentelemetry/semantic-conventions": "^1.27.0"
@@ -8368,14 +8368,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
       },
       "funding": {
         "type": "github",
@@ -13095,9 +13095,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@map-colonies/mc-priority-queue": "^9.1.2",
     "@map-colonies/mc-utils": "^6.0.1",
     "@map-colonies/prometheus": "^1.0.0",
-    "@map-colonies/raster-shared": "^8.1.0",
+    "@map-colonies/raster-shared": "^8.3.0-alpha.0",
     "@map-colonies/read-pkg": "^1.0.0",
     "@map-colonies/schemas": "^1.18.0",
     "@map-colonies/shapefile-reader": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@map-colonies/mc-priority-queue": "^9.1.2",
     "@map-colonies/mc-utils": "^6.0.1",
     "@map-colonies/prometheus": "^1.0.0",
-    "@map-colonies/raster-shared": "^8.3.0-alpha.0",
+    "@map-colonies/raster-shared": "^8.3.0-alpha.1",
     "@map-colonies/read-pkg": "^1.0.0",
     "@map-colonies/schemas": "^1.18.0",
     "@map-colonies/shapefile-reader": "^1.0.1",

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -51,6 +51,14 @@ export class UpdateLayerError extends Error {
   }
 }
 
+export class DeleteLayerError extends Error {
+  public constructor(targetClient: string, layerIdentifier: string, err: Error) {
+    super(`Failed to delete layer ${layerIdentifier} from ${targetClient} client: ${err.message}`);
+    this.name = DeleteLayerError.name;
+    this.stack = err.stack;
+  }
+}
+
 export class LayerNotFoundError extends Error {
   public constructor(id: string) {
     super(`Record with id ${id} not found`);

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -338,7 +338,7 @@ export interface GetMapproxyCacheRequest {
 export interface GetMapproxyCacheResponse {
   cacheName: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  cache: { type: LayerCacheType; bucket_name?: string };
+  cache: { type: LayerCacheType; directory?: string; directory_layout?: string; bucket_name?: string };
 }
 //#endregion mapproxyApi
 

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -327,7 +327,8 @@ export interface GetMapproxyCacheRequest {
 
 export interface GetMapproxyCacheResponse {
   cacheName: string;
-  cache: { type: LayerCacheType };
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  cache: { type: LayerCacheType; bucket_name?: string };
 }
 //#endregion mapproxyApi
 

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -67,6 +67,7 @@ export interface IngestionPollingJobsConfig {
   new: JobConfig | undefined;
   update: JobConfig | undefined;
   swapUpdate: JobConfig | undefined;
+  deleteLayer: JobConfig | undefined;
 }
 
 export interface ExportPollingJobsConfig {
@@ -90,6 +91,7 @@ export interface PollingTasks {
   createTasks: string;
   init: string;
   finalize: string;
+  delete: string;
 }
 
 export interface PollingConfig {
@@ -137,9 +139,17 @@ export interface JobManagementConfig {
 //#endregion config
 
 //#region job/task interfaces
-export interface IJobHandler<TInitJob = unknown, TInitTask = unknown, TFinalizeJob = unknown, TFinalizeTask = unknown> {
-  handleJobInit: (job: TInitJob, task: TInitTask) => Promise<void>;
-  handleJobFinalize: (job: TFinalizeJob, task: TFinalizeTask) => Promise<void>;
+export interface IJobHandler<
+  TInitJob = unknown,
+  TInitTask = unknown,
+  TFinalizeJob = unknown,
+  TFinalizeTask = unknown,
+  TDeleteJob = unknown,
+  TDeleteTask = unknown,
+> {
+  handleJobInit?: (job: TInitJob, task: TInitTask) => Promise<void>;
+  handleJobFinalize?: (job: TFinalizeJob, task: TFinalizeTask) => Promise<void>;
+  handleJobDelete?: (job: TDeleteJob, task: TDeleteTask) => Promise<void>;
 }
 
 export interface JobAndTaskResponse {

--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -412,7 +412,8 @@ export interface IS3Config {
   accessKeyId: string;
   secretAccessKey: string;
   endpointUrl: string;
-  bucket: string;
+  artifactsBucket: string;
+  tilesBucket: string;
   objectKey: string;
   sslEnabled: boolean;
 }

--- a/src/containerConfig.ts
+++ b/src/containerConfig.ts
@@ -18,6 +18,7 @@ import { ExportJobHandler } from './job/models/export/exportJobHandler';
 import { NewJobHandler } from './job/models/ingestion/newJobHandler';
 import { SwapJobHandler } from './job/models/ingestion/swapJobHandler';
 import { UpdateJobHandler } from './job/models/ingestion/updateJobHandler';
+import { DeleteLayerHandler } from './job/models/deletion/deleteLayerHandler';
 import { JOB_HANDLER_FACTORY_SYMBOL, jobHandlerFactory } from './job/models/jobHandlerFactory';
 import { getPollingJobs, parseInstanceType, validateAndGetHandlersTokens } from './utils/configUtil';
 import { productReaderFactory } from './utils/storage/productReader';
@@ -71,6 +72,8 @@ const registerInstanceHandlers = (instanceType: InstanceType, handlersTokens: Re
         { token: handlersTokens['Ingestion_Update']!, provider: { useClass: UpdateJobHandler } },
 
         { token: handlersTokens['Ingestion_Swap_Update']!, provider: { useClass: SwapJobHandler } },
+
+        { token: handlersTokens['Delete_Layer']!, provider: { useClass: DeleteLayerHandler } },
       ];
     case 'export':
       return [{ token: handlersTokens['Export']!, provider: { useClass: ExportJobHandler } }];

--- a/src/httpClients/catalogClient.ts
+++ b/src/httpClients/catalogClient.ts
@@ -10,7 +10,8 @@ import type { IConfig, CatalogUpdateRequestBody, FindLayerResponse, FindLayerBod
 import { IngestionNewFinalizeJob, IngestionSwapUpdateFinalizeJob, IngestionUpdateFinalizeJob } from '../utils/zod/schemas/job.schema';
 import { SERVICES } from '../common/constants';
 import { internalIdSchema } from '../utils/zod/schemas/jobParameters.schema';
-import { LayerNotFoundError, PublishLayerError, UpdateLayerError } from '../common/errors';
+import { NotFoundError } from '@map-colonies/error-types';
+import { DeleteLayerError, LayerNotFoundError, PublishLayerError, UpdateLayerError } from '../common/errors';
 import { LinkBuilder, type ILinkBuilderData } from '../utils/linkBuilder';
 import { PolygonPartsMangerClient } from './polygonPartsMangerClient';
 
@@ -80,6 +81,32 @@ export class CatalogClient extends HttpClient {
           activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
           activeSpan?.recordException(err);
           throw new UpdateLayerError(this.targetService, internalId, err);
+        }
+      } finally {
+        activeSpan?.end();
+      }
+    });
+  }
+
+  public async deleteRecord(catalogId: string): Promise<void> {
+    await context.with(trace.setSpan(context.active(), this.tracer.startSpan(`${CatalogClient.name}.${this.deleteRecord.name}`)), async () => {
+      const activeSpan = trace.getActiveSpan();
+      activeSpan?.setAttribute('catalogId', catalogId);
+
+      try {
+        const url = `/records/${catalogId}`;
+        await this.delete(url);
+        activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Catalog record deleted successfully' });
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          this.logger.warn({ msg: 'catalog record not found, treating as already deleted', catalogId });
+          activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Catalog record already absent' });
+          return;
+        }
+        if (err instanceof Error) {
+          activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+          activeSpan?.recordException(err);
+          throw new DeleteLayerError(this.targetService, catalogId, err);
         }
       } finally {
         activeSpan?.end();

--- a/src/httpClients/catalogClient.ts
+++ b/src/httpClients/catalogClient.ts
@@ -2,6 +2,7 @@ import type { Logger } from '@map-colonies/js-logger';
 import { LayerNameFormats, PolygonPartsEntityName, type LayerName } from '@map-colonies/raster-shared';
 import { HttpClient, type IHttpRetryConfig } from '@map-colonies/mc-utils';
 import { type IRasterCatalogUpsertRequestBody, LayerMetadata, Link, PycswLayerCatalogRecord } from '@map-colonies/mc-model-types';
+import { NotFoundError } from '@map-colonies/error-types';
 import { RecordType } from '@map-colonies/types';
 import { context, SpanStatusCode, trace, type Tracer } from '@opentelemetry/api';
 import { inject, injectable } from 'tsyringe';
@@ -9,7 +10,6 @@ import type { IConfig, CatalogUpdateRequestBody, FindLayerResponse, FindLayerBod
 import { IngestionNewFinalizeJob, IngestionSwapUpdateFinalizeJob, IngestionUpdateFinalizeJob } from '../utils/zod/schemas/job.schema';
 import { SERVICES } from '../common/constants';
 import { internalIdSchema } from '../utils/zod/schemas/jobParameters.schema';
-import { NotFoundError } from '@map-colonies/error-types';
 import { DeleteLayerError, LayerNotFoundError, PublishLayerError, UpdateLayerError } from '../common/errors';
 import { LinkBuilder, type ILinkBuilderData } from '../utils/linkBuilder';
 import { PolygonPartsMangerClient } from './polygonPartsMangerClient';

--- a/src/httpClients/catalogClient.ts
+++ b/src/httpClients/catalogClient.ts
@@ -98,8 +98,8 @@ export class CatalogClient extends HttpClient {
         activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Catalog record deleted successfully' });
       } catch (err) {
         if (err instanceof NotFoundError) {
-          this.logger.warn({ msg: 'catalog record not found, treating as already deleted', catalogId });
-          activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Catalog record already absent' });
+          this.logger.warn({ msg: 'catalog record not found, skipping', catalogId });
+          activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'catalog record not found, skipping' });
           return;
         }
         if (err instanceof Error) {

--- a/src/httpClients/geoserverClient.ts
+++ b/src/httpClients/geoserverClient.ts
@@ -3,9 +3,10 @@ import type { LayerNameFormats } from '@map-colonies/raster-shared';
 import { HttpClient, type IHttpRetryConfig } from '@map-colonies/mc-utils';
 import { context, SpanStatusCode, trace, type Tracer } from '@opentelemetry/api';
 import { inject, injectable } from 'tsyringe';
+import { NotFoundError } from '@map-colonies/error-types';
 import type { IConfig, InsertGeoserverRequest } from '../common/interfaces';
 import { SERVICES } from '../common/constants';
-import { PublishLayerError } from '../common/errors';
+import { DeleteLayerError, PublishLayerError } from '../common/errors';
 
 @injectable()
 export class GeoserverClient extends HttpClient {
@@ -46,6 +47,33 @@ export class GeoserverClient extends HttpClient {
           activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
           activeSpan?.recordException(err);
           throw new PublishLayerError(this.targetService, layerName, err);
+        }
+      } finally {
+        activeSpan?.end();
+      }
+    });
+  }
+
+  public async deleteLayer(layerName: string): Promise<void> {
+    await context.with(trace.setSpan(context.active(), this.tracer.startSpan(`${GeoserverClient.name}.${this.deleteLayer.name}`)), async () => {
+      const activeSpan = trace.getActiveSpan();
+      activeSpan?.setAttribute('layerName', layerName);
+
+      try {
+        const url = `/featureTypes/${this.workspace}/${this.dataStore}/${layerName}`;
+        await this.delete(url);
+        activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Layer deleted successfully from geoserver' });
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          // already gone — deletion is idempotent, a 404 on (re)run is success (§6)
+          this.logger.warn({ msg: 'Layer feature type not found in geoserver, treating as already deleted', layerName });
+          activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Layer already absent in geoserver' });
+          return;
+        }
+        if (err instanceof Error) {
+          activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+          activeSpan?.recordException(err);
+          throw new DeleteLayerError(this.targetService, layerName, err);
         }
       } finally {
         activeSpan?.end();

--- a/src/httpClients/geoserverClient.ts
+++ b/src/httpClients/geoserverClient.ts
@@ -54,19 +54,19 @@ export class GeoserverClient extends HttpClient {
     });
   }
 
-  public async deleteLayer(layerName: string): Promise<void> {
-    await context.with(trace.setSpan(context.active(), this.tracer.startSpan(`${GeoserverClient.name}.${this.deleteLayer.name}`)), async () => {
+  public async unpublishLayer(layerName: string): Promise<void> {
+    await context.with(trace.setSpan(context.active(), this.tracer.startSpan(`${GeoserverClient.name}.${this.unpublishLayer.name}`)), async () => {
       const activeSpan = trace.getActiveSpan();
       activeSpan?.setAttribute('layerName', layerName);
 
       try {
         const url = `/featureTypes/${this.workspace}/${this.dataStore}/${layerName}`;
         await this.delete(url);
-        activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Layer deleted successfully from geoserver' });
+        activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Layer unpublished successfully from geoserver' });
       } catch (err) {
         if (err instanceof NotFoundError) {
-          // already gone — deletion is idempotent, a 404 on (re)run is success (§6)
-          this.logger.warn({ msg: 'Layer feature type not found in geoserver, treating as already deleted', layerName });
+          // already gone — unpublish is idempotent, a 404 on (re)run is success (§6)
+          this.logger.warn({ msg: 'Layer feature type not found in geoserver, treating as already unpublished', layerName });
           activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Layer already absent in geoserver' });
           return;
         }

--- a/src/httpClients/geoserverClient.ts
+++ b/src/httpClients/geoserverClient.ts
@@ -66,8 +66,8 @@ export class GeoserverClient extends HttpClient {
       } catch (err) {
         if (err instanceof NotFoundError) {
           // already gone — unpublish is idempotent, a 404 on (re)run is success (§6)
-          this.logger.warn({ msg: 'Layer feature type not found in geoserver, treating as already unpublished', layerName });
-          activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Layer already absent in geoserver' });
+          this.logger.warn({ msg: 'Layer feature type not found in geoserver, skipping', layerName });
+          activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Layer feature type not found in geoserver, skipping' });
           return;
         }
         if (err instanceof Error) {

--- a/src/httpClients/geoserverClient.ts
+++ b/src/httpClients/geoserverClient.ts
@@ -61,7 +61,7 @@ export class GeoserverClient extends HttpClient {
 
       try {
         const url = `/featureTypes/${this.workspace}/${this.dataStore}/${layerName}`;
-        await this.delete(url);
+        await this.delete(url, { isRecursive: true });
         activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Layer unpublished successfully from geoserver' });
       } catch (err) {
         if (err instanceof NotFoundError) {

--- a/src/httpClients/mapproxyClient.ts
+++ b/src/httpClients/mapproxyClient.ts
@@ -127,7 +127,22 @@ export class MapproxyApiClient extends HttpClient {
   }
 
   public async getLayerCache(layerName: LayerName): Promise<GetMapproxyCacheResponse | undefined> {
-    const cacheType = this.layerCacheType;
+    return this.fetchLayerCache(layerName, this.layerCacheType);
+  }
+
+  public async getCacheName(getCacheReq: GetMapproxyCacheRequest): Promise<string> {
+    const { layerName, cacheType } = getCacheReq;
+    const res = await this.fetchLayerCache(layerName, cacheType);
+    if (res === undefined) {
+      throw new LayerCacheNotFoundError(layerName, cacheType);
+    }
+    if (res.cache.type !== LayerCacheType.REDIS) {
+      throw new UnsupportedLayerCacheError(layerName, cacheType);
+    }
+    return res.cacheName;
+  }
+
+  private async fetchLayerCache(layerName: LayerName, cacheType: LayerCacheType): Promise<GetMapproxyCacheResponse | undefined> {
     const url = `layer/${layerName}/${cacheType}`;
     try {
       return await this.get<GetMapproxyCacheResponse>(url);
@@ -135,24 +150,6 @@ export class MapproxyApiClient extends HttpClient {
       if (err instanceof NotFoundError) {
         this.logger.warn({ msg: 'layer cache not found in mapproxy', layerName, cacheType });
         return undefined;
-      }
-      throw err;
-    }
-  }
-
-  public async getCacheName(getCacheReq: GetMapproxyCacheRequest): Promise<string> {
-    const url = `layer/${getCacheReq.layerName}/${getCacheReq.cacheType}`;
-    try {
-      const res = await this.get<GetMapproxyCacheResponse>(url);
-      const { cache, cacheName } = res;
-      if (cache.type !== LayerCacheType.REDIS) {
-        throw new UnsupportedLayerCacheError(getCacheReq.layerName, getCacheReq.cacheType);
-      }
-      return cacheName;
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        this.logger.warn({ msg: 'Cache not found', layerName: getCacheReq.layerName, cacheType: getCacheReq.cacheType });
-        throw new LayerCacheNotFoundError(getCacheReq.layerName, getCacheReq.cacheType);
       }
       throw err;
     }

--- a/src/httpClients/mapproxyClient.ts
+++ b/src/httpClients/mapproxyClient.ts
@@ -1,5 +1,5 @@
 import type { Logger } from '@map-colonies/js-logger';
-import type { TileOutputFormat } from '@map-colonies/raster-shared';
+import type { LayerName, TileOutputFormat } from '@map-colonies/raster-shared';
 import { context, SpanStatusCode, trace, type Tracer } from '@opentelemetry/api';
 import { HttpClient, type IHttpRetryConfig } from '@map-colonies/mc-utils';
 import { inject, injectable } from 'tsyringe';
@@ -124,6 +124,21 @@ export class MapproxyApiClient extends HttpClient {
         activeSpan?.end();
       }
     });
+  }
+
+  public async getS3CacheBucketName(layerName: LayerName): Promise<string | undefined> {
+    const url = `layer/${layerName}/${LayerCacheType.S3}`;
+    try {
+      const res = await this.get<GetMapproxyCacheResponse>(url);
+      // bucket_name is absent when the layer cache relies on mapproxy's global default s3 bucket
+      return res.cache.bucket_name;
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        this.logger.warn({ msg: 's3 cache not found in mapproxy for layer', layerName });
+        return undefined;
+      }
+      throw err;
+    }
   }
 
   public async getCacheName(getCacheReq: GetMapproxyCacheRequest): Promise<string> {

--- a/src/httpClients/mapproxyClient.ts
+++ b/src/httpClients/mapproxyClient.ts
@@ -110,15 +110,10 @@ export class MapproxyApiClient extends HttpClient {
           activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'layer not found in mapproxy, skipping' });
           return;
         }
-        if (err instanceof DeleteLayerError) {
-          activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
-          activeSpan?.recordException(err);
-          throw err;
-        }
         if (err instanceof Error) {
           activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
           activeSpan?.recordException(err);
-          throw new DeleteLayerError(this.targetService, layerName, err);
+          throw err instanceof DeleteLayerError ? err : new DeleteLayerError(this.targetService, layerName, err);
         }
       } finally {
         activeSpan?.end();

--- a/src/httpClients/mapproxyClient.ts
+++ b/src/httpClients/mapproxyClient.ts
@@ -106,8 +106,8 @@ export class MapproxyApiClient extends HttpClient {
         activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Layer removed successfully from mapproxy' });
       } catch (err) {
         if (err instanceof NotFoundError) {
-          this.logger.warn({ msg: 'layer not found in mapproxy, treating as already removed', layerName });
-          activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Layer already absent in mapproxy' });
+          this.logger.warn({ msg: 'layer not found in mapproxy, skipping', layerName });
+          activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'layer not found in mapproxy, skipping' });
           return;
         }
         if (err instanceof DeleteLayerError) {
@@ -130,7 +130,7 @@ export class MapproxyApiClient extends HttpClient {
     return this.fetchLayerCache(layerName, this.layerCacheType);
   }
 
-  public async getCacheName(getCacheReq: GetMapproxyCacheRequest): Promise<string> {
+  public async getRedisCacheName(getCacheReq: GetMapproxyCacheRequest): Promise<string> {
     const { layerName, cacheType } = getCacheReq;
     const res = await this.fetchLayerCache(layerName, cacheType);
     if (res === undefined) {

--- a/src/httpClients/mapproxyClient.ts
+++ b/src/httpClients/mapproxyClient.ts
@@ -126,15 +126,14 @@ export class MapproxyApiClient extends HttpClient {
     });
   }
 
-  public async getS3CacheBucketName(layerName: LayerName): Promise<string | undefined> {
-    const url = `layer/${layerName}/${LayerCacheType.S3}`;
+  public async getLayerCache(layerName: LayerName): Promise<GetMapproxyCacheResponse | undefined> {
+    const cacheType = this.layerCacheType;
+    const url = `layer/${layerName}/${cacheType}`;
     try {
-      const res = await this.get<GetMapproxyCacheResponse>(url);
-      // bucket_name is absent when the layer cache relies on mapproxy's global default s3 bucket
-      return res.cache.bucket_name;
+      return await this.get<GetMapproxyCacheResponse>(url);
     } catch (err) {
       if (err instanceof NotFoundError) {
-        this.logger.warn({ msg: 's3 cache not found in mapproxy for layer', layerName });
+        this.logger.warn({ msg: 'layer cache not found in mapproxy', layerName, cacheType });
         return undefined;
       }
       throw err;

--- a/src/httpClients/mapproxyClient.ts
+++ b/src/httpClients/mapproxyClient.ts
@@ -7,6 +7,7 @@ import { NotFoundError } from '@map-colonies/error-types';
 import type { IConfig, GetMapproxyCacheRequest, GetMapproxyCacheResponse, PublishMapLayerRequest } from '../common/interfaces';
 import { LayerCacheType, SERVICES, storageProviderToCacheTypeMap, StorageProvider } from '../common/constants';
 import {
+  DeleteLayerError,
   LayerCacheNotFoundError,
   PublishLayerError,
   UnsupportedLayerCacheError,
@@ -85,6 +86,39 @@ export class MapproxyApiClient extends HttpClient {
           activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
           activeSpan?.recordException(err);
           throw new UpdateLayerError(this.targetService, layerName, err);
+        }
+      } finally {
+        activeSpan?.end();
+      }
+    });
+  }
+
+  public async removeLayer(layerName: string): Promise<void> {
+    await context.with(trace.setSpan(context.active(), this.tracer.startSpan(`${MapproxyApiClient.name}.${this.removeLayer.name}`)), async () => {
+      const activeSpan = trace.getActiveSpan();
+      activeSpan?.setAttribute('layerName', layerName);
+
+      try {
+        const failed = await this.delete<string[]>('/layer', { layerNames: [layerName] });
+        if (failed.includes(layerName)) {
+          throw new DeleteLayerError(this.targetService, layerName, new Error(`mapproxy reported layer as failed to remove`));
+        }
+        activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Layer removed successfully from mapproxy' });
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          this.logger.warn({ msg: 'layer not found in mapproxy, treating as already removed', layerName });
+          activeSpan?.setStatus({ code: SpanStatusCode.OK, message: 'Layer already absent in mapproxy' });
+          return;
+        }
+        if (err instanceof DeleteLayerError) {
+          activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+          activeSpan?.recordException(err);
+          throw err;
+        }
+        if (err instanceof Error) {
+          activeSpan?.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+          activeSpan?.recordException(err);
+          throw new DeleteLayerError(this.targetService, layerName, err);
         }
       } finally {
         activeSpan?.end();

--- a/src/httpClients/polygonPartsMangerClient.ts
+++ b/src/httpClients/polygonPartsMangerClient.ts
@@ -7,10 +7,11 @@ import type {
 } from '@map-colonies/raster-shared';
 import { HttpClient, type IHttpRetryConfig } from '@map-colonies/mc-utils';
 import { inject, injectable } from 'tsyringe';
+import { NotFoundError } from '@map-colonies/error-types';
 import type { IConfig } from '../common/interfaces';
 import { POLYGON_PARTS_MANAGER_SERVICE_NAME, SERVICES } from '../common/constants';
 import { requiredAggregationFeatureSchema } from '../utils/zod/schemas/aggregation.schema';
-import { LayerMetadataAggregationError, PolygonPartsProcessingError, IntersectionError } from '../common/errors';
+import { DeleteLayerError, LayerMetadataAggregationError, PolygonPartsProcessingError, IntersectionError } from '../common/errors';
 import { AggregationLayerMetadata, PolygonPartsProcessPayload } from '../common/interfaces';
 
 @injectable()
@@ -69,6 +70,19 @@ export class PolygonPartsMangerClient extends HttpClient {
       const intersectionError = new IntersectionError(err, polygonPartsEntityName);
       this.logger.error({ msg: intersectionError.message, polygonPartsEntityName, err });
       throw intersectionError;
+    }
+  }
+
+  public async deleteEntities(polygonPartsEntityName: string): Promise<void> {
+    try {
+      this.logger.info({ msg: 'deleting polygon parts entities', polygonPartsEntityName });
+      await this.delete(`/polygonParts/${polygonPartsEntityName}`);
+    } catch (err) {
+      if (err instanceof NotFoundError) {
+        this.logger.warn({ msg: 'polygon parts entity not found, treating as already deleted', polygonPartsEntityName });
+        return;
+      }
+      throw new DeleteLayerError(this.targetService, polygonPartsEntityName, err instanceof Error ? err : new Error(String(err)));
     }
   }
 

--- a/src/httpClients/polygonPartsMangerClient.ts
+++ b/src/httpClients/polygonPartsMangerClient.ts
@@ -79,7 +79,7 @@ export class PolygonPartsMangerClient extends HttpClient {
       await this.delete(`/polygonParts/${polygonPartsEntityName}`);
     } catch (err) {
       if (err instanceof NotFoundError) {
-        this.logger.warn({ msg: 'polygon parts entity not found, treating as already deleted', polygonPartsEntityName });
+        this.logger.warn({ msg: 'polygon parts entity not found, skipping', polygonPartsEntityName });
         return;
       }
       throw new DeleteLayerError(this.targetService, polygonPartsEntityName, err instanceof Error ? err : new Error(String(err)));

--- a/src/job/models/deletion/deleteLayerHandler.ts
+++ b/src/job/models/deletion/deleteLayerHandler.ts
@@ -6,8 +6,8 @@ import {
   deleteTaskParamsSchema,
   SourceType,
   type DeleteTaskParams,
+  type DeleteStoredResourcesParams,
   type LayerName,
-  type LayerTilesDeletionParams,
 } from '@map-colonies/raster-shared';
 import { inject, injectable } from 'tsyringe';
 import type { IConfig, IJobHandler } from '../../../common/interfaces';
@@ -24,6 +24,8 @@ import { JobHandler } from '../jobHandler';
 @injectable()
 export class DeleteLayerHandler extends JobHandler implements IJobHandler<never, never, never, never, DeleteLayerJob, DeleteTask> {
   private readonly tilesDeletionType: string;
+  private readonly tilesStorageProvider: StorageProvider;
+  private readonly tilesBucketConfig: string;
 
   public constructor(
     @inject(SERVICES.LOGGER) logger: Logger,
@@ -40,6 +42,8 @@ export class DeleteLayerHandler extends JobHandler implements IJobHandler<never,
     super(logger, config, queueClient, jobTrackerClient);
     // whole-layer tiles deletion shares the 'tiles-deletion' task type with the range-based ingestion flow (raster-shared DeletionTaskTypes.LayerTilesDeletion); the Cleaner distinguishes them by params shape
     this.tilesDeletionType = this.config.get<string>('jobManagement.ingestion.tasks.tilesDeletion.type');
+    this.tilesStorageProvider = this.config.get<StorageProvider>('tilesStorageProvider');
+    this.tilesBucketConfig = this.config.get<string>('S3.tilesBucket');
   }
 
   public async handleJobDelete(job: DeleteLayerJob, task: DeleteTask): Promise<void> {
@@ -53,8 +57,6 @@ export class DeleteLayerHandler extends JobHandler implements IJobHandler<never,
         try {
           const catalogId = job.internalId;
           const { layerName, polygonPartsEntityName } = this.validateAndGenerateLayerNameFormats(job);
-          // resolved before the deleteFromMapproxy step — once the layer is removed from mapproxy, getCache
-          // returns 404 and only the S3.tilesBucket config fallback remains (relevant for redelivered tasks)
           const tilesBucket = await this.resolveTilesBucket(layerName);
           // parse to apply the schema defaults (undefined → false) and narrow to the required-boolean output type
           let params: DeleteTaskParams = deleteTaskParamsSchema.parse(task.parameters);
@@ -102,8 +104,7 @@ export class DeleteLayerHandler extends JobHandler implements IJobHandler<never,
   }
 
   private async resolveTilesBucket(layerName: LayerName): Promise<string | undefined> {
-    const sourceProvider = this.config.get<StorageProvider>('tilesStorageProvider');
-    if (sourceProvider !== SourceType.S3) {
+    if (this.tilesStorageProvider !== SourceType.S3) {
       return undefined;
     }
 
@@ -112,17 +113,19 @@ export class DeleteLayerHandler extends JobHandler implements IJobHandler<never,
       return mapproxyBucket;
     }
 
-    const configBucket = this.config.get<string>('S3.tilesBucket');
-    this.logger.warn({ msg: 'tiles bucket could not be resolved from mapproxy cache, falling back to configuration', layerName, configBucket });
-    return configBucket;
+    this.logger.warn({
+      msg: 'tiles bucket could not be resolved from mapproxy cache, falling back to configuration',
+      layerName,
+      bucket: this.tilesBucketConfig,
+    });
+    return this.tilesBucketConfig;
   }
 
   private async createCleanerTasks(job: DeleteLayerJob, catalogId: string, bucket: string | undefined): Promise<void> {
-    const sourceProvider = this.config.get<StorageProvider>('tilesStorageProvider');
     const logger = this.logger.child({ jobId: job.id, catalogId });
 
     // idempotency guard (§6): a redelivered task must not create duplicate cleaner tasks
-    const existingTilesTasks = await this.queueClient.jobManagerClient.findTasks<LayerTilesDeletionParams>({
+    const existingTilesTasks = await this.queueClient.jobManagerClient.findTasks<DeleteStoredResourcesParams>({
       jobId: job.id,
       type: this.tilesDeletionType,
     });
@@ -132,13 +135,17 @@ export class DeleteLayerHandler extends JobHandler implements IJobHandler<never,
       return;
     }
 
-    const tilesDeletionTask: ICreateTaskBody<LayerTilesDeletionParams> = {
+    const storage =
+      this.tilesStorageProvider === SourceType.S3
+        ? { storageProvider: this.tilesStorageProvider, bucket: bucket ?? '' }
+        : { storageProvider: this.tilesStorageProvider };
+    const tilesDeletionTask: ICreateTaskBody<DeleteStoredResourcesParams> = {
       type: this.tilesDeletionType,
       description: 'full layer tiles deletion',
-      parameters: { catalogId, sourceProvider, bucket },
+      parameters: { paths: [catalogId], ...storage },
     };
 
-    logger.info({ msg: 'creating layer tiles deletion task', sourceProvider, bucket });
+    logger.info({ msg: 'creating layer tiles deletion task', storageProvider: this.tilesStorageProvider, bucket });
     await this.queueClient.jobManagerClient.createTaskForJob(job.id, tilesDeletionTask);
 
     // TODO(§11 open questions): artifacts-deletion task creation is deferred — the existence source of truth

--- a/src/job/models/deletion/deleteLayerHandler.ts
+++ b/src/job/models/deletion/deleteLayerHandler.ts
@@ -1,25 +1,31 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import type { Logger } from '@map-colonies/js-logger';
 import { context, trace, type Tracer } from '@opentelemetry/api';
 import { TaskHandler as QueueClient, type ICreateTaskBody } from '@map-colonies/mc-priority-queue';
-import {
-  deleteTaskParamsSchema,
-  SourceType,
-  type DeleteTaskParams,
-  type DeleteStoredResourcesParams,
-  type LayerName,
-} from '@map-colonies/raster-shared';
+import { SourceType, type DeleteTaskParams, type DeleteStoredResourcesParams, type LayerName } from '@map-colonies/raster-shared';
 import { inject, injectable } from 'tsyringe';
-import type { IConfig, IJobHandler } from '../../../common/interfaces';
+import type { IConfig, IJobHandler, JobAndTaskTelemetry, StepKey } from '../../../common/interfaces';
 import { SERVICES, type StorageProvider } from '../../../common/constants';
+import { LayerCacheNotFoundError } from '../../../common/errors';
 import { CatalogClient } from '../../../httpClients/catalogClient';
 import { GeoserverClient } from '../../../httpClients/geoserverClient';
 import { MapproxyApiClient } from '../../../httpClients/mapproxyClient';
 import { PolygonPartsMangerClient } from '../../../httpClients/polygonPartsMangerClient';
 import { JobTrackerClient } from '../../../httpClients/jobTrackerClient';
 import { TaskMetrics } from '../../../utils/metrics/taskMetrics';
-import type { DeleteLayerJob, DeleteTask } from '../../../utils/zod/schemas/job.schema';
+import {
+  extendedDeleteTaskParamsSchema,
+  type DeleteLayerJob,
+  type DeleteTask,
+  type ExtendedDeleteTaskParams,
+  type TilesLocation,
+} from '../../../utils/zod/schemas/job.schema';
 import { JobHandler } from '../jobHandler';
+
+/** An ordered metadata-deletion step: the params flag that records its completion and the deletion it performs. */
+interface DeletionStep {
+  step: StepKey<ExtendedDeleteTaskParams>;
+  run: () => Promise<unknown>;
+}
 
 @injectable()
 export class DeleteLayerHandler extends JobHandler implements IJobHandler<never, never, never, never, DeleteLayerJob, DeleteTask> {
@@ -51,51 +57,11 @@ export class DeleteLayerHandler extends JobHandler implements IJobHandler<never,
       trace.setSpan(context.active(), this.tracer.startSpan(`${DeleteLayerHandler.name}.${this.handleJobDelete.name}`)),
       async () => {
         const activeSpan = trace.getActiveSpan();
-        const logger = this.logger.child({ jobId: job.id, taskId: task.id, jobType: job.type, taskType: task.type });
-        const taskProcessTracking = this.taskMetrics.trackTaskProcessing(job.type, task.type);
-
+        const telemetry: JobAndTaskTelemetry = { taskTracker: this.taskMetrics.trackTaskProcessing(job.type, task.type), tracingSpan: activeSpan };
         try {
-          const catalogId = job.internalId;
-          const { layerName, polygonPartsEntityName } = this.validateAndGenerateLayerNameFormats(job);
-          const tilesBucket = await this.resolveTilesBucket(layerName);
-          // parse to apply the schema defaults (undefined → false) and narrow to the required-boolean output type
-          let params: DeleteTaskParams = deleteTaskParamsSchema.parse(task.parameters);
-          activeSpan?.setAttributes({ catalogId, layerName, polygonPartsEntityName });
-          activeSpan?.addEvent(`${job.type}.${task.type}.start`, { ...params });
-          logger.info({ msg: `handling ${job.type} job with ${task.type} task`, catalogId });
-
-          // ordered metadata deletion — persist each boolean immediately so a redelivered task resumes from the failed step (§4.2, §6)
-          if (!params.deleteFromCatalog) {
-            await this.catalogClient.deleteRecord(catalogId);
-            params = await this.markFinalizeStepAsCompleted(job.id, task.id, params, 'deleteFromCatalog');
-            activeSpan?.addEvent('deleteFromCatalog.success', { ...params });
-          }
-
-          if (!params.deleteFromGeoserver) {
-            await this.geoserverClient.unpublishLayer(layerName);
-            params = await this.markFinalizeStepAsCompleted(job.id, task.id, params, 'deleteFromGeoserver');
-            activeSpan?.addEvent('deleteFromGeoserver.success', { ...params });
-          }
-
-          if (!params.deletePolygonParts) {
-            await this.polygonPartsMangerClient.deleteEntities(polygonPartsEntityName);
-            params = await this.markFinalizeStepAsCompleted(job.id, task.id, params, 'deletePolygonParts');
-            activeSpan?.addEvent('deletePolygonParts.success', { ...params });
-          }
-
-          if (!params.deleteFromMapproxy) {
-            await this.mapproxyClient.removeLayer(layerName);
-            params = await this.markFinalizeStepAsCompleted(job.id, task.id, params, 'deleteFromMapproxy');
-            activeSpan?.addEvent('deleteFromMapproxy.success', { ...params });
-          }
-
-          if (this.isAllStepsCompleted(params)) {
-            logger.info({ msg: 'all metadata deletion steps completed, creating downstream cleaner tasks', ...params });
-            await this.createCleanerTasks(job, catalogId, tilesBucket);
-            await this.completeTask(job, task, { taskTracker: taskProcessTracking, tracingSpan: activeSpan });
-          }
+          await this.runDeletionFlow(job, task, telemetry);
         } catch (err) {
-          await this.handleError(err, job, task, { taskTracker: taskProcessTracking, tracingSpan: activeSpan });
+          await this.handleError(err, job, task, telemetry);
         } finally {
           activeSpan?.end();
         }
@@ -103,53 +69,122 @@ export class DeleteLayerHandler extends JobHandler implements IJobHandler<never,
     );
   }
 
-  private async resolveTilesBucket(layerName: LayerName): Promise<string | undefined> {
+  private async runDeletionFlow(job: DeleteLayerJob, task: DeleteTask, telemetry: JobAndTaskTelemetry): Promise<void> {
+    const activeSpan = telemetry.tracingSpan;
+    const logger = this.logger.child({ jobId: job.id, taskId: task.id, jobType: job.type, taskType: task.type });
+    const catalogId = job.internalId;
+    const { layerName, polygonPartsEntityName } = this.validateAndGenerateLayerNameFormats(job);
+
+    // parse to apply the schema defaults (undefined → false) and narrow to the required-boolean output type
+    let params = extendedDeleteTaskParamsSchema.parse(task.parameters);
+    activeSpan?.setAttributes({ catalogId, layerName, polygonPartsEntityName });
+    activeSpan?.addEvent(`${job.type}.${task.type}.start`, { ...this.getSteps(params) });
+    logger.info({ msg: `handling ${job.type} job with ${task.type} task`, catalogId });
+
+    // the mapproxy cache is the only source of the tiles directory and the deleteFromMapproxy step destroys it,
+    // resolve and persist the location before any deletion step — a redelivered task reads it from its own params
+    let tilesLocation = params.tilesLocation;
+    if (tilesLocation === undefined) {
+      tilesLocation = await this.resolveTilesLocation(layerName);
+      params = { ...params, tilesLocation };
+      await this.queueClient.jobManagerClient.updateTask(job.id, task.id, { parameters: params });
+      logger.info({ msg: 'tiles location resolved from mapproxy cache and persisted', ...tilesLocation });
+      activeSpan?.addEvent('tilesLocation.resolved', { ...tilesLocation });
+    }
+
+    // ordered metadata deletion — persist each step immediately so a redelivered task resumes from where it failed (§4.2, §6)
+    const deletionSteps: DeletionStep[] = [
+      { step: 'deleteFromCatalog', run: async () => this.catalogClient.deleteRecord(catalogId) },
+      { step: 'deleteFromGeoserver', run: async () => this.geoserverClient.unpublishLayer(layerName) },
+      { step: 'deletePolygonParts', run: async () => this.polygonPartsMangerClient.deleteEntities(polygonPartsEntityName) },
+      { step: 'deleteFromMapproxy', run: async () => this.mapproxyClient.removeLayer(layerName) },
+    ];
+    for (const { step, run } of deletionSteps) {
+      if (params[step]) {
+        continue;
+      }
+      await run();
+      params = await this.markFinalizeStepAsCompleted(job.id, task.id, params, step);
+      activeSpan?.addEvent(`${step}.success`, { ...this.getSteps(params) });
+    }
+
+    const steps = this.getSteps(params);
+    if (this.isAllStepsCompleted(steps)) {
+      logger.info({ msg: 'all metadata deletion steps completed, creating downstream cleaner tasks', ...steps });
+      await this.createCleanerTasks(job, tilesLocation);
+      await this.completeTask(job, task, telemetry);
+    }
+  }
+
+  // the persisted tilesLocation is not a completion step — strip it so step checks and span events see only the booleans
+  private getSteps(params: ExtendedDeleteTaskParams): DeleteTaskParams {
+    const { deleteFromCatalog, deleteFromGeoserver, deletePolygonParts, deleteFromMapproxy } = params;
+    return { deleteFromCatalog, deleteFromGeoserver, deletePolygonParts, deleteFromMapproxy };
+  }
+
+  private async resolveTilesLocation(layerName: LayerName): Promise<TilesLocation> {
+    const cache = await this.mapproxyClient.getLayerCache(layerName);
+    const directory = cache?.cache.directory;
+    if (directory === undefined) {
+      throw new LayerCacheNotFoundError(layerName, this.tilesStorageProvider);
+    }
+
+    const path = this.toRelativeTilesPath(directory);
+    if (path === '') {
+      throw new LayerCacheNotFoundError(layerName, this.tilesStorageProvider);
+    }
+
     if (this.tilesStorageProvider !== SourceType.S3) {
-      return undefined;
+      return { path };
     }
+    return { path, bucket: this.resolveTilesBucket(cache?.cache.bucket_name, layerName) };
+  }
 
-    const mapproxyBucket = await this.mapproxyClient.getS3CacheBucketName(layerName);
-    if (mapproxyBucket !== undefined) {
-      return mapproxyBucket;
+  /**
+   * Normalizes the mapproxy cache directory into the relative path the Cleaner expects.
+   * - S3: object keys carry no leading slash (mapproxy strips it when writing tiles), so only the leading slash is dropped.
+   * - FS: the first segment is mapproxy's tiles-PVC mount path; the Cleaner remounts the same PVC at its own base, so it is dropped.
+   */
+  private toRelativeTilesPath(directory: string): string {
+    return this.tilesStorageProvider === SourceType.S3 ? directory.replace(/^\/+/, '') : directory.replace(/^\/?[^/]+\//, '');
+  }
+
+  private resolveTilesBucket(cacheBucket: string | undefined, layerName: LayerName): string {
+    if (cacheBucket !== undefined) {
+      return cacheBucket;
     }
-
-    this.logger.warn({
-      msg: 'tiles bucket could not be resolved from mapproxy cache, falling back to configuration',
-      layerName,
-      bucket: this.tilesBucketConfig,
-    });
+    this.logger.warn({ msg: 'tiles bucket not present on mapproxy cache, falling back to configuration', layerName, bucket: this.tilesBucketConfig });
     return this.tilesBucketConfig;
   }
 
-  private async createCleanerTasks(job: DeleteLayerJob, catalogId: string, bucket: string | undefined): Promise<void> {
-    const logger = this.logger.child({ jobId: job.id, catalogId });
+  private async createCleanerTasks(job: DeleteLayerJob, tilesLocation: TilesLocation): Promise<void> {
+    const logger = this.logger.child({ jobId: job.id });
 
     // idempotency guard (§6): a redelivered task must not create duplicate cleaner tasks
     const existingTilesTasks = await this.queueClient.jobManagerClient.findTasks<DeleteStoredResourcesParams>({
       jobId: job.id,
       type: this.tilesDeletionType,
     });
-
     if (existingTilesTasks && existingTilesTasks.length > 0) {
       logger.info({ msg: 'layer tiles deletion task already exists, skipping creation', type: this.tilesDeletionType });
       return;
     }
 
+    // bucket is always resolved for S3 in resolveTilesLocation; the fallback only satisfies the optional TilesLocation.bucket type
     const storage =
       this.tilesStorageProvider === SourceType.S3
-        ? { storageProvider: this.tilesStorageProvider, bucket: bucket ?? '' }
+        ? { storageProvider: this.tilesStorageProvider, bucket: tilesLocation.bucket ?? this.tilesBucketConfig }
         : { storageProvider: this.tilesStorageProvider };
+
     const tilesDeletionTask: ICreateTaskBody<DeleteStoredResourcesParams> = {
       type: this.tilesDeletionType,
       description: 'full layer tiles deletion',
-      parameters: { paths: [catalogId], ...storage },
+      parameters: { paths: [tilesLocation.path], ...storage },
     };
 
-    logger.info({ msg: 'creating layer tiles deletion task', storageProvider: this.tilesStorageProvider, bucket });
+    logger.info({ msg: 'creating layer tiles deletion task', storageProvider: this.tilesStorageProvider, ...tilesLocation });
     await this.queueClient.jobManagerClient.createTaskForJob(job.id, tilesDeletionTask);
 
-    // TODO(§11 open questions): artifacts-deletion task creation is deferred — the existence source of truth
-    // (mapproxy GET /layer does not expose artifacts) and the params shape (catalogId-derived vs explicit paths)
-    // are unresolved. Surface in the PR description.
+    // TODO: create cleaner tasks for artifacts deletion
   }
 }

--- a/src/job/models/deletion/deleteLayerHandler.ts
+++ b/src/job/models/deletion/deleteLayerHandler.ts
@@ -1,0 +1,148 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import type { Logger } from '@map-colonies/js-logger';
+import { context, trace, type Tracer } from '@opentelemetry/api';
+import { TaskHandler as QueueClient, type ICreateTaskBody } from '@map-colonies/mc-priority-queue';
+import {
+  deleteTaskParamsSchema,
+  SourceType,
+  type DeleteTaskParams,
+  type LayerName,
+  type LayerTilesDeletionParams,
+} from '@map-colonies/raster-shared';
+import { inject, injectable } from 'tsyringe';
+import type { IConfig, IJobHandler } from '../../../common/interfaces';
+import { SERVICES, type StorageProvider } from '../../../common/constants';
+import { CatalogClient } from '../../../httpClients/catalogClient';
+import { GeoserverClient } from '../../../httpClients/geoserverClient';
+import { MapproxyApiClient } from '../../../httpClients/mapproxyClient';
+import { PolygonPartsMangerClient } from '../../../httpClients/polygonPartsMangerClient';
+import { JobTrackerClient } from '../../../httpClients/jobTrackerClient';
+import { TaskMetrics } from '../../../utils/metrics/taskMetrics';
+import type { DeleteLayerJob, DeleteTask } from '../../../utils/zod/schemas/job.schema';
+import { JobHandler } from '../jobHandler';
+
+@injectable()
+export class DeleteLayerHandler extends JobHandler implements IJobHandler<never, never, never, never, DeleteLayerJob, DeleteTask> {
+  private readonly tilesDeletionType: string;
+
+  public constructor(
+    @inject(SERVICES.LOGGER) logger: Logger,
+    @inject(SERVICES.CONFIG) protected override readonly config: IConfig,
+    @inject(SERVICES.TRACER) public readonly tracer: Tracer,
+    @inject(SERVICES.QUEUE_CLIENT) queueClient: QueueClient,
+    @inject(CatalogClient) private readonly catalogClient: CatalogClient,
+    @inject(GeoserverClient) private readonly geoserverClient: GeoserverClient,
+    @inject(PolygonPartsMangerClient) private readonly polygonPartsMangerClient: PolygonPartsMangerClient,
+    @inject(MapproxyApiClient) private readonly mapproxyClient: MapproxyApiClient,
+    @inject(JobTrackerClient) jobTrackerClient: JobTrackerClient,
+    private readonly taskMetrics: TaskMetrics
+  ) {
+    super(logger, config, queueClient, jobTrackerClient);
+    // whole-layer tiles deletion shares the 'tiles-deletion' task type with the range-based ingestion flow (raster-shared DeletionTaskTypes.LayerTilesDeletion); the Cleaner distinguishes them by params shape
+    this.tilesDeletionType = this.config.get<string>('jobManagement.ingestion.tasks.tilesDeletion.type');
+  }
+
+  public async handleJobDelete(job: DeleteLayerJob, task: DeleteTask): Promise<void> {
+    await context.with(
+      trace.setSpan(context.active(), this.tracer.startSpan(`${DeleteLayerHandler.name}.${this.handleJobDelete.name}`)),
+      async () => {
+        const activeSpan = trace.getActiveSpan();
+        const logger = this.logger.child({ jobId: job.id, taskId: task.id, jobType: job.type, taskType: task.type });
+        const taskProcessTracking = this.taskMetrics.trackTaskProcessing(job.type, task.type);
+
+        try {
+          const catalogId = job.internalId;
+          const { layerName, polygonPartsEntityName } = this.validateAndGenerateLayerNameFormats(job);
+          // resolved before the deleteFromMapproxy step — once the layer is removed from mapproxy, getCache
+          // returns 404 and only the S3.tilesBucket config fallback remains (relevant for redelivered tasks)
+          const tilesBucket = await this.resolveTilesBucket(layerName);
+          // parse to apply the schema defaults (undefined → false) and narrow to the required-boolean output type
+          let params: DeleteTaskParams = deleteTaskParamsSchema.parse(task.parameters);
+          activeSpan?.setAttributes({ catalogId, layerName, polygonPartsEntityName });
+          activeSpan?.addEvent(`${job.type}.${task.type}.start`, { ...params });
+          logger.info({ msg: `handling ${job.type} job with ${task.type} task`, catalogId });
+
+          // ordered metadata deletion — persist each boolean immediately so a redelivered task resumes from the failed step (§4.2, §6)
+          if (!params.deleteFromCatalog) {
+            await this.catalogClient.deleteRecord(catalogId);
+            params = await this.markFinalizeStepAsCompleted(job.id, task.id, params, 'deleteFromCatalog');
+            activeSpan?.addEvent('deleteFromCatalog.success', { ...params });
+          }
+
+          if (!params.deleteFromGeoserver) {
+            await this.geoserverClient.unpublishLayer(layerName);
+            params = await this.markFinalizeStepAsCompleted(job.id, task.id, params, 'deleteFromGeoserver');
+            activeSpan?.addEvent('deleteFromGeoserver.success', { ...params });
+          }
+
+          if (!params.deletePolygonParts) {
+            await this.polygonPartsMangerClient.deleteEntities(polygonPartsEntityName);
+            params = await this.markFinalizeStepAsCompleted(job.id, task.id, params, 'deletePolygonParts');
+            activeSpan?.addEvent('deletePolygonParts.success', { ...params });
+          }
+
+          if (!params.deleteFromMapproxy) {
+            await this.mapproxyClient.removeLayer(layerName);
+            params = await this.markFinalizeStepAsCompleted(job.id, task.id, params, 'deleteFromMapproxy');
+            activeSpan?.addEvent('deleteFromMapproxy.success', { ...params });
+          }
+
+          if (this.isAllStepsCompleted(params)) {
+            logger.info({ msg: 'all metadata deletion steps completed, creating downstream cleaner tasks', ...params });
+            await this.createCleanerTasks(job, catalogId, tilesBucket);
+            await this.completeTask(job, task, { taskTracker: taskProcessTracking, tracingSpan: activeSpan });
+          }
+        } catch (err) {
+          await this.handleError(err, job, task, { taskTracker: taskProcessTracking, tracingSpan: activeSpan });
+        } finally {
+          activeSpan?.end();
+        }
+      }
+    );
+  }
+
+  private async resolveTilesBucket(layerName: LayerName): Promise<string | undefined> {
+    const sourceProvider = this.config.get<StorageProvider>('tilesStorageProvider');
+    if (sourceProvider !== SourceType.S3) {
+      return undefined;
+    }
+
+    const mapproxyBucket = await this.mapproxyClient.getS3CacheBucketName(layerName);
+    if (mapproxyBucket !== undefined) {
+      return mapproxyBucket;
+    }
+
+    const configBucket = this.config.get<string>('S3.tilesBucket');
+    this.logger.warn({ msg: 'tiles bucket could not be resolved from mapproxy cache, falling back to configuration', layerName, configBucket });
+    return configBucket;
+  }
+
+  private async createCleanerTasks(job: DeleteLayerJob, catalogId: string, bucket: string | undefined): Promise<void> {
+    const sourceProvider = this.config.get<StorageProvider>('tilesStorageProvider');
+    const logger = this.logger.child({ jobId: job.id, catalogId });
+
+    // idempotency guard (§6): a redelivered task must not create duplicate cleaner tasks
+    const existingTilesTasks = await this.queueClient.jobManagerClient.findTasks<LayerTilesDeletionParams>({
+      jobId: job.id,
+      type: this.tilesDeletionType,
+    });
+
+    if (existingTilesTasks && existingTilesTasks.length > 0) {
+      logger.info({ msg: 'layer tiles deletion task already exists, skipping creation', type: this.tilesDeletionType });
+      return;
+    }
+
+    const tilesDeletionTask: ICreateTaskBody<LayerTilesDeletionParams> = {
+      type: this.tilesDeletionType,
+      description: 'full layer tiles deletion',
+      parameters: { catalogId, sourceProvider, bucket },
+    };
+
+    logger.info({ msg: 'creating layer tiles deletion task', sourceProvider, bucket });
+    await this.queueClient.jobManagerClient.createTaskForJob(job.id, tilesDeletionTask);
+
+    // TODO(§11 open questions): artifacts-deletion task creation is deferred — the existence source of truth
+    // (mapproxy GET /layer does not expose artifacts) and the params shape (catalogId-derived vs explicit paths)
+    // are unresolved. Surface in the PR description.
+  }
+}

--- a/src/job/models/deletion/deleteLayerHandler.ts
+++ b/src/job/models/deletion/deleteLayerHandler.ts
@@ -109,8 +109,8 @@ export class DeleteLayerHandler extends JobHandler implements IJobHandler<never,
       activeSpan?.addEvent(`${step}.success`, { ...steps });
     }
 
-    if (this.isAllStepsCompleted(steps)) {
-      logger.info({ msg: 'all metadata deletion steps completed, creating downstream cleaner tasks', ...steps });
+    if (this.isAllStepsCompleted(this.getSteps(params))) {
+      logger.info({ msg: 'all metadata deletion steps completed, creating downstream cleaner tasks', ...this.getSteps(params) });
       await this.createCleanerTasks(job, tilesLocation);
       await this.completeTask(job, task, telemetry);
     }
@@ -160,16 +160,6 @@ export class DeleteLayerHandler extends JobHandler implements IJobHandler<never,
   private async createCleanerTasks(job: DeleteLayerJob, tilesLocation: TilesLocation): Promise<void> {
     const logger = this.logger.child({ jobId: job.id });
 
-    // idempotency guard (§6): a redelivered task must not create duplicate cleaner tasks
-    const existingTilesTasks = await this.queueClient.jobManagerClient.findTasks<DeleteStoredResourcesParams>({
-      jobId: job.id,
-      type: this.tilesDeletionType,
-    });
-    if (existingTilesTasks && existingTilesTasks.length > 0) {
-      logger.info({ msg: 'layer tiles deletion task already exists, skipping creation', type: this.tilesDeletionType });
-      return;
-    }
-
     // bucket is always resolved for S3 in resolveTilesLocation; the fallback only satisfies the optional TilesLocation.bucket type
     const storage =
       this.tilesStorageProvider === SourceType.S3
@@ -179,6 +169,7 @@ export class DeleteLayerHandler extends JobHandler implements IJobHandler<never,
     const tilesDeletionTask: ICreateTaskBody<DeleteStoredResourcesParams> = {
       type: this.tilesDeletionType,
       description: 'full layer tiles deletion',
+      blockDuplication: true,
       parameters: { paths: [tilesLocation.path], ...storage },
     };
 

--- a/src/job/models/deletion/deleteLayerHandler.ts
+++ b/src/job/models/deletion/deleteLayerHandler.ts
@@ -77,8 +77,9 @@ export class DeleteLayerHandler extends JobHandler implements IJobHandler<never,
 
     // parse to apply the schema defaults (undefined → false) and narrow to the required-boolean output type
     let params = extendedDeleteTaskParamsSchema.parse(task.parameters);
+    const steps = this.getSteps(params);
     activeSpan?.setAttributes({ catalogId, layerName, polygonPartsEntityName });
-    activeSpan?.addEvent(`${job.type}.${task.type}.start`, { ...this.getSteps(params) });
+    activeSpan?.addEvent(`${job.type}.${task.type}.start`, { ...steps });
     logger.info({ msg: `handling ${job.type} job with ${task.type} task`, catalogId });
 
     // the mapproxy cache is the only source of the tiles directory and the deleteFromMapproxy step destroys it,
@@ -105,10 +106,9 @@ export class DeleteLayerHandler extends JobHandler implements IJobHandler<never,
       }
       await run();
       params = await this.markFinalizeStepAsCompleted(job.id, task.id, params, step);
-      activeSpan?.addEvent(`${step}.success`, { ...this.getSteps(params) });
+      activeSpan?.addEvent(`${step}.success`, { ...steps });
     }
 
-    const steps = this.getSteps(params);
     if (this.isAllStepsCompleted(steps)) {
       logger.info({ msg: 'all metadata deletion steps completed, creating downstream cleaner tasks', ...steps });
       await this.createCleanerTasks(job, tilesLocation);

--- a/src/job/models/ingestion/seedingJobCreator.ts
+++ b/src/job/models/ingestion/seedingJobCreator.ts
@@ -62,8 +62,8 @@ export class SeedingJobCreator {
 
         logger.debug({ msg: 'Getting cache name for layer', layerName });
 
-        const cacheName = await this.mapproxyClient.getCacheName({ layerName, cacheType: LayerCacheType.REDIS });
-        activeSpan?.addEvent('getCacheName.success', { cacheName });
+        const cacheName = await this.mapproxyClient.getRedisCacheName({ layerName, cacheType: LayerCacheType.REDIS });
+        activeSpan?.addEvent('getRedisCacheName.success', { cacheName });
 
         const validCatalogId = internalIdSchema.parse(ingestionJob).internalId;
 

--- a/src/job/models/jobProcessor.ts
+++ b/src/job/models/jobProcessor.ts
@@ -94,10 +94,16 @@ export class JobProcessor {
         switch (task.type) {
           case taskTypes.createTasks:
           case taskTypes.init: // when export domain will have validation we will remove init and move to createTasks
+            this.assertHandlerSupportsTask(jobHandler.handleJobInit, job.type, task.type);
             await jobHandler.handleJobInit(job, task);
             break;
           case taskTypes.finalize:
+            this.assertHandlerSupportsTask(jobHandler.handleJobFinalize, job.type, task.type);
             await jobHandler.handleJobFinalize(job, task);
+            break;
+          case taskTypes.delete:
+            this.assertHandlerSupportsTask(jobHandler.handleJobDelete, job.type, task.type);
+            await jobHandler.handleJobDelete(job, task);
             break;
         }
       } catch (err) {
@@ -174,6 +180,12 @@ export class JobProcessor {
     }
     logger.info({ msg: `dequeued task ${task.id} successfully` });
     return { task, shouldSkipTask: false };
+  }
+
+  private assertHandlerSupportsTask<F>(handlerMethod: F | undefined, jobType: string, taskType: string): asserts handlerMethod is F {
+    if (handlerMethod === undefined) {
+      throw new Error(`Job handler for job type "${jobType}" does not support task type "${taskType}"`);
+    }
   }
 
   private validateTaskAndJob(jobAndTask: JobAndTaskResponse): void {

--- a/src/job/models/jobProcessor.ts
+++ b/src/job/models/jobProcessor.ts
@@ -6,7 +6,7 @@ import { inject, injectable } from 'tsyringe';
 import { SERVICES } from '../../common/constants';
 import type { IConfig, JobAndTaskResponse, PollingConfig, TaskResponse, JobManagementConfig } from '../../common/interfaces';
 import { JobTrackerClient } from '../../httpClients/jobTrackerClient';
-import { getAvailableJobTypes, getPollingJobs } from '../../utils/configUtil';
+import { getAvailableJobTypes, getPollingJobs, getPollingTaskTypes } from '../../utils/configUtil';
 import type { InstanceType } from '../../utils/zod/schemas/instance.schema';
 import { jobTaskSchemaMap, OperationValidationKey } from '../../utils/zod/schemas/job.schema';
 import { JOB_HANDLER_FACTORY_SYMBOL, type JobHandlerFactory } from './jobHandlerFactory';
@@ -29,11 +29,10 @@ export class JobProcessor {
   ) {
     this.dequeueIntervalMs = this.config.get<number>('jobManagement.config.dequeueIntervalMs');
     this.pollingConfig = this.config.get<PollingConfig>('jobManagement.polling');
-    const { tasks } = this.pollingConfig;
     const jobManagementConfig = this.config.get<JobManagementConfig>('jobManagement');
     const jobs = getPollingJobs(jobManagementConfig, this.instanceType);
     this.pollingJobTypes = getAvailableJobTypes(jobs);
-    this.pollingTaskTypes = [tasks.createTasks, tasks.init, tasks.finalize];
+    this.pollingTaskTypes = getPollingTaskTypes(this.pollingConfig.tasks, this.instanceType);
   }
 
   public async start(): Promise<void> {

--- a/src/job/models/jobProcessor.ts
+++ b/src/job/models/jobProcessor.ts
@@ -151,7 +151,7 @@ export class JobProcessor {
 
     const job = await this.queueClient.jobManagerClient.getJob(jobId);
 
-    if (taskType === this.pollingConfig.tasks.init) {
+    if (taskType === this.pollingConfig.tasks.init || taskType === this.pollingConfig.tasks.delete) {
       // currently only export jobs use the init task to change status to IN_PROGRESS
       await this.queueClient.jobManagerClient.updateJob(jobId, { status: OperationStatus.IN_PROGRESS });
     }

--- a/src/utils/configUtil.ts
+++ b/src/utils/configUtil.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { INSTANCE_TYPES } from '../common/constants';
 import { InvalidConfigError, MissingConfigError } from '../common/errors';
-import type { JobManagementConfig, PollingJobs } from '../common/interfaces';
+import type { JobManagementConfig, PollingJobs, PollingTasks } from '../common/interfaces';
 import { instanceTypeSchema, type InstanceType } from './zod/schemas/instance.schema';
 
 function isStringEmpty(str: string): boolean {
@@ -23,7 +23,7 @@ export const getAvailableJobTypes = (ingestionConfig: PollingJobs): string[] => 
 };
 
 export const validateAndGetHandlersTokens = (pollingConfig: PollingJobs, instanceType: InstanceType): Record<string, string> => {
-  const { new: newJob, update: updateJob, swapUpdate: swapUpdateJob, export: exportJob } = pollingConfig;
+  const { new: newJob, update: updateJob, swapUpdate: swapUpdateJob, export: exportJob, deleteLayer: deleteLayerJob } = pollingConfig;
 
   switch (instanceType) {
     case 'ingestion': {
@@ -36,8 +36,16 @@ export const validateAndGetHandlersTokens = (pollingConfig: PollingJobs, instanc
       if (swapUpdateJob?.type === undefined || isStringEmpty(swapUpdateJob.type)) {
         throw new MissingConfigError('Missing "swap-update-job" type configuration');
       }
+      if (deleteLayerJob?.type === undefined || isStringEmpty(deleteLayerJob.type)) {
+        throw new MissingConfigError('Missing "delete-layer-job" type configuration');
+      }
 
-      return { Ingestion_New: newJob.type, Ingestion_Update: updateJob.type, Ingestion_Swap_Update: swapUpdateJob.type };
+      return {
+        Ingestion_New: newJob.type,
+        Ingestion_Update: updateJob.type,
+        Ingestion_Swap_Update: swapUpdateJob.type,
+        Delete_Layer: deleteLayerJob.type,
+      };
     }
     case 'export': {
       if (exportJob?.type === undefined || isStringEmpty(exportJob.type)) {
@@ -57,6 +65,16 @@ export const getPollingJobs = (jobManagementConfig: JobManagementConfig, instanc
       return jobManagementConfig.ingestion.pollingJobs;
     case 'export':
       return jobManagementConfig.export.pollingJobs;
+  }
+};
+
+export const getPollingTaskTypes = (pollingTasks: PollingTasks, instanceType: InstanceType): string[] => {
+  const { createTasks, init, finalize, delete: deleteTask } = pollingTasks;
+  switch (instanceType) {
+    case 'ingestion':
+      return [createTasks, init, finalize, deleteTask];
+    case 'export':
+      return [createTasks, init, finalize];
   }
 };
 

--- a/src/utils/storage/s3Service.ts
+++ b/src/utils/storage/s3Service.ts
@@ -41,12 +41,12 @@ export class S3Service {
   public async uploadFiles(files: UploadFile[]): Promise<string[]> {
     return context.with(trace.setSpan(context.active(), this.tracer.startSpan(`${S3Service.name}.${this.uploadFiles.name}`)), async () => {
       const activeSpan = trace.getActiveSpan();
-      const { bucket, endpointUrl } = this.s3Config;
-      const logger = this.logger.child({ bucket, endpointUrl });
+      const { artifactsBucket, endpointUrl } = this.s3Config;
+      const logger = this.logger.child({ bucket: artifactsBucket, endpointUrl });
       try {
         activeSpan?.setAttributes({
           endpointUrl,
-          bucket,
+          bucket: artifactsBucket,
           fileCount: files.length,
         });
 
@@ -68,7 +68,7 @@ export class S3Service {
             client: this.client,
             params: {
               Key: s3Key,
-              Bucket: bucket,
+              Bucket: artifactsBucket,
               ContentType: contentType,
               Body: fs.createReadStream(filePath),
             },

--- a/src/utils/zod/schemas/job.schema.ts
+++ b/src/utils/zod/schemas/job.schema.ts
@@ -110,7 +110,18 @@ export const deleteLayerJobSchema = createJobResponseSchema(deleteLayerJobParams
   .describe('DeleteLayerJobSchema');
 export type DeleteLayerJob = z.infer<typeof deleteLayerJobSchema>;
 
-export const deleteTaskSchema = createTaskResponseSchema(deleteTaskParamsSchema).describe('DeleteTaskSchema');
+export const tilesLocationSchema = z.object({
+  path: z.string().min(1),
+  bucket: z.string().optional(),
+});
+export type TilesLocation = z.infer<typeof tilesLocationSchema>;
+
+export const extendedDeleteTaskParamsSchema = deleteTaskParamsSchema.extend({
+  tilesLocation: tilesLocationSchema.optional(),
+});
+export type ExtendedDeleteTaskParams = z.infer<typeof extendedDeleteTaskParamsSchema>;
+
+export const deleteTaskSchema = createTaskResponseSchema(extendedDeleteTaskParamsSchema).describe('DeleteTaskSchema');
 export type DeleteTask = z.infer<typeof deleteTaskSchema>;
 //#endregion
 

--- a/src/utils/zod/schemas/job.schema.ts
+++ b/src/utils/zod/schemas/job.schema.ts
@@ -14,6 +14,8 @@ import {
   taskBlockDuplicationParamSchema,
   exportFinalizeTaskParamsSchema,
   rasterProductTypeSchema,
+  deleteLayerJobParamsSchema,
+  deleteTaskParamsSchema,
 } from '@map-colonies/raster-shared';
 import {
   ingestionNewExtendedJobParamsSchema,
@@ -101,6 +103,17 @@ export type ExportFinalizeTask = z.infer<typeof exportFinalizeTaskSchema>;
 export type ExportFinalizeTaskParams = z.infer<typeof exportFinalizeTaskParamsSchema>;
 //#endregion
 
+//#region Deletion
+export const deleteLayerJobSchema = createJobResponseSchema(deleteLayerJobParamsSchema)
+  .and(internalIdSchema)
+  .and(z.object({ productType: rasterProductTypeSchema }))
+  .describe('DeleteLayerJobSchema');
+export type DeleteLayerJob = z.infer<typeof deleteLayerJobSchema>;
+
+export const deleteTaskSchema = createTaskResponseSchema(deleteTaskParamsSchema).describe('DeleteTaskSchema');
+export type DeleteTask = z.infer<typeof deleteTaskSchema>;
+//#endregion
+
 // Ingestion domain types
 type IngestionJobType = 'Ingestion_New' | 'Ingestion_Update' | 'Ingestion_Swap_Update';
 type IngestionTaskType = 'create-tasks' | 'finalize';
@@ -109,8 +122,15 @@ type IngestionTaskType = 'create-tasks' | 'finalize';
 type ExportJobType = 'Export';
 type ExportTaskType = 'init' | 'finalize';
 
+// Deletion domain types
+type DeletionJobType = 'Delete_Layer';
+type DeletionTaskType = 'delete';
+
 // Operation validation key allows only valid job-task combinations
-export type OperationValidationKey = `${IngestionJobType}_${IngestionTaskType}` | `${ExportJobType}_${ExportTaskType}`;
+export type OperationValidationKey =
+  | `${IngestionJobType}_${IngestionTaskType}`
+  | `${ExportJobType}_${ExportTaskType}`
+  | `${DeletionJobType}_${DeletionTaskType}`;
 
 export interface JobTaskSchema {
   jobSchema: z.ZodTypeAny;
@@ -151,5 +171,9 @@ export const jobTaskSchemaMap: JobTaskSchemasMap = {
   Export_finalize: {
     jobSchema: exportJobSchema,
     taskSchema: exportFinalizeTaskSchema,
+  },
+  Delete_Layer_delete: {
+    jobSchema: deleteLayerJobSchema,
+    taskSchema: deleteTaskSchema,
   },
 };

--- a/tests/unit/httpClients/catalogClient.spec.ts
+++ b/tests/unit/httpClients/catalogClient.spec.ts
@@ -4,7 +4,7 @@ import type { Mocked } from 'vitest';
 import nock from 'nock';
 import { clear as clearConfig, configMock, registerDefaultConfig } from '../mocks/configMock';
 import { type IngestionSwapUpdateFinalizeJob } from '../../../src/utils/zod/schemas/job.schema';
-import { LayerNotFoundError, PublishLayerError, UpdateLayerError } from '../../../src/common/errors';
+import { DeleteLayerError, LayerNotFoundError, PublishLayerError, UpdateLayerError } from '../../../src/common/errors';
 import { exportJob, ingestionNewJobExtended, ingestionSwapUpdateJob, ingestionUpdateFinalizeJob, ingestionUpdateJob } from '../mocks/jobsMockData';
 import type { FindLayerResponse } from '../../../src/common/interfaces';
 import { layerRecord } from '../mocks/catalogClientMockData';
@@ -168,6 +168,43 @@ describe('CatalogClient', () => {
       const action = catalogClient.findLayer(nonExistingRecordId);
 
       await expect(action).rejects.toThrow(LayerNotFoundError);
+    });
+  });
+
+  describe('deleteRecord', () => {
+    it('should delete a catalog record', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.catalogManager');
+      const catalogId = randomUUID();
+
+      nock(baseUrl).delete(`/records/${catalogId}`).reply(200);
+
+      const action = catalogClient.deleteRecord(catalogId);
+
+      await expect(action).resolves.not.toThrow();
+      // eslint-disable-next-line import-x/no-named-as-default-member
+      expect(nock.isDone()).toBe(true);
+    });
+
+    it('should treat a 404 as success (idempotent re-run)', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.catalogManager');
+      const catalogId = randomUUID();
+
+      nock(baseUrl).delete(`/records/${catalogId}`).reply(404);
+
+      const action = catalogClient.deleteRecord(catalogId);
+
+      await expect(action).resolves.not.toThrow();
+    });
+
+    it('should throw DeleteLayerError on a server error', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.catalogManager');
+      const catalogId = randomUUID();
+
+      nock(baseUrl).delete(`/records/${catalogId}`).reply(500);
+
+      const action = catalogClient.deleteRecord(catalogId);
+
+      await expect(action).rejects.toThrow(DeleteLayerError);
     });
   });
 });

--- a/tests/unit/httpClients/geoserverClient.spec.ts
+++ b/tests/unit/httpClients/geoserverClient.spec.ts
@@ -63,7 +63,7 @@ describe('GeoserverClient', () => {
       const dataStore = configMock.get<string>('geoserver.dataStore');
       const layerName = 'test-Orthophoto';
 
-      nock(baseUrl).delete(`/featureTypes/${workspace}/${dataStore}/${layerName}`).reply(204);
+      nock(baseUrl).delete(`/featureTypes/${workspace}/${dataStore}/${layerName}`).query({ isRecursive: true }).reply(204);
 
       const action = geoServerClient.unpublishLayer(layerName);
 
@@ -78,7 +78,7 @@ describe('GeoserverClient', () => {
       const dataStore = configMock.get<string>('geoserver.dataStore');
       const layerName = 'already-gone-Orthophoto';
 
-      nock(baseUrl).delete(`/featureTypes/${workspace}/${dataStore}/${layerName}`).reply(404);
+      nock(baseUrl).delete(`/featureTypes/${workspace}/${dataStore}/${layerName}`).query({ isRecursive: true }).reply(404);
 
       const action = geoServerClient.unpublishLayer(layerName);
 
@@ -91,7 +91,7 @@ describe('GeoserverClient', () => {
       const dataStore = configMock.get<string>('geoserver.dataStore');
       const layerName = 'error_test-Orthophoto';
 
-      nock(baseUrl).delete(`/featureTypes/${workspace}/${dataStore}/${layerName}`).reply(500);
+      nock(baseUrl).delete(`/featureTypes/${workspace}/${dataStore}/${layerName}`).query({ isRecursive: true }).reply(500);
 
       const action = geoServerClient.unpublishLayer(layerName);
 

--- a/tests/unit/httpClients/geoserverClient.spec.ts
+++ b/tests/unit/httpClients/geoserverClient.spec.ts
@@ -56,8 +56,8 @@ describe('GeoserverClient', () => {
     await expect(action).rejects.toThrow(PublishLayerError);
   });
 
-  describe('delete', () => {
-    it('should delete a layer feature type from geoserver', async () => {
+  describe('unpublishLayer', () => {
+    it('should unpublish a layer feature type from geoserver', async () => {
       const baseUrl = configMock.get<string>('servicesUrl.geoserverApi');
       const workspace = configMock.get<string>('geoserver.workspace');
       const dataStore = configMock.get<string>('geoserver.dataStore');
@@ -65,7 +65,7 @@ describe('GeoserverClient', () => {
 
       nock(baseUrl).delete(`/featureTypes/${workspace}/${dataStore}/${layerName}`).reply(204);
 
-      const action = geoServerClient.deleteLayer(layerName);
+      const action = geoServerClient.unpublishLayer(layerName);
 
       await expect(action).resolves.not.toThrow();
       // eslint-disable-next-line import-x/no-named-as-default-member
@@ -80,7 +80,7 @@ describe('GeoserverClient', () => {
 
       nock(baseUrl).delete(`/featureTypes/${workspace}/${dataStore}/${layerName}`).reply(404);
 
-      const action = geoServerClient.deleteLayer(layerName);
+      const action = geoServerClient.unpublishLayer(layerName);
 
       await expect(action).resolves.not.toThrow();
     });
@@ -93,7 +93,7 @@ describe('GeoserverClient', () => {
 
       nock(baseUrl).delete(`/featureTypes/${workspace}/${dataStore}/${layerName}`).reply(500);
 
-      const action = geoServerClient.deleteLayer(layerName);
+      const action = geoServerClient.unpublishLayer(layerName);
 
       await expect(action).rejects.toThrow(DeleteLayerError);
     });

--- a/tests/unit/httpClients/geoserverClient.spec.ts
+++ b/tests/unit/httpClients/geoserverClient.spec.ts
@@ -3,7 +3,7 @@ import type { LayerNameFormats } from '@map-colonies/raster-shared';
 import { getTestLogger } from '../../configurations/testLogger';
 import { GeoserverClient } from '../../../src/httpClients/geoserverClient';
 import { configMock, registerDefaultConfig } from '../mocks/configMock';
-import { PublishLayerError } from '../../../src/common/errors';
+import { DeleteLayerError, PublishLayerError } from '../../../src/common/errors';
 import { tracerMock } from '../mocks/tracerMock';
 
 describe('GeoserverClient', () => {
@@ -54,5 +54,48 @@ describe('GeoserverClient', () => {
     const action = geoServerClient.publish(layersName);
 
     await expect(action).rejects.toThrow(PublishLayerError);
+  });
+
+  describe('delete', () => {
+    it('should delete a layer feature type from geoserver', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.geoserverApi');
+      const workspace = configMock.get<string>('geoserver.workspace');
+      const dataStore = configMock.get<string>('geoserver.dataStore');
+      const layerName = 'test-Orthophoto';
+
+      nock(baseUrl).delete(`/featureTypes/${workspace}/${dataStore}/${layerName}`).reply(204);
+
+      const action = geoServerClient.deleteLayer(layerName);
+
+      await expect(action).resolves.not.toThrow();
+      // eslint-disable-next-line import-x/no-named-as-default-member
+      expect(nock.isDone()).toBe(true);
+    });
+
+    it('should treat a 404 as success (idempotent re-run)', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.geoserverApi');
+      const workspace = configMock.get<string>('geoserver.workspace');
+      const dataStore = configMock.get<string>('geoserver.dataStore');
+      const layerName = 'already-gone-Orthophoto';
+
+      nock(baseUrl).delete(`/featureTypes/${workspace}/${dataStore}/${layerName}`).reply(404);
+
+      const action = geoServerClient.deleteLayer(layerName);
+
+      await expect(action).resolves.not.toThrow();
+    });
+
+    it('should throw DeleteLayerError on a server error', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.geoserverApi');
+      const workspace = configMock.get<string>('geoserver.workspace');
+      const dataStore = configMock.get<string>('geoserver.dataStore');
+      const layerName = 'error_test-Orthophoto';
+
+      nock(baseUrl).delete(`/featureTypes/${workspace}/${dataStore}/${layerName}`).reply(500);
+
+      const action = geoServerClient.deleteLayer(layerName);
+
+      await expect(action).rejects.toThrow(DeleteLayerError);
+    });
   });
 });

--- a/tests/unit/httpClients/mapproxyClient.spec.ts
+++ b/tests/unit/httpClients/mapproxyClient.spec.ts
@@ -162,44 +162,50 @@ describe('mapproxyClient', () => {
     });
   });
 
-  describe('getS3CacheBucketName', () => {
-    it('should return the bucket name of the layer s3 cache', async () => {
+  describe('getLayerCache', () => {
+    it('should return the layer cache for the configured storage provider (FS → file cache)', async () => {
       const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
       const layerName: LayerName = 'test-Orthophoto';
-      const bucketName = 'raster-tiles-bucket';
-
-      nock(baseUrl)
-        .get(`/layer/${layerName}/${LayerCacheType.S3}`)
+      const cacheResponse = {
+        cacheName: layerName,
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        .reply(200, { cacheName: 'cacheName', cache: { type: LayerCacheType.S3, bucket_name: bucketName } });
+        cache: { type: LayerCacheType.FS, directory: '/outputs/catalog-id/display-path/', directory_layout: 'tms' },
+      };
 
-      const action = mapproxyApiClient.getS3CacheBucketName(layerName);
+      nock(baseUrl).get(`/layer/${layerName}/${LayerCacheType.FS}`).reply(200, cacheResponse);
 
-      await expect(action).resolves.toBe(bucketName);
+      const action = mapproxyApiClient.getLayerCache(layerName);
+
+      await expect(action).resolves.toEqual(cacheResponse);
       // eslint-disable-next-line import-x/no-named-as-default-member
       expect(nock.isDone()).toBe(true);
     });
 
-    it('should return undefined when the cache has no bucket_name (global default bucket)', async () => {
+    it('should return the s3 cache including bucket_name when the provider is S3', async () => {
+      setValue('tilesStorageProvider', 'S3');
+      mapproxyApiClient = new MapproxyApiClient(configMock, await getTestLogger(), tracerMock);
       const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
       const layerName: LayerName = 'test-Orthophoto';
+      const cacheResponse = {
+        cacheName: layerName,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        cache: { type: LayerCacheType.S3, directory: '/catalog-id/display-path/', directory_layout: 'tms', bucket_name: 'raster-tiles-bucket' },
+      };
 
-      nock(baseUrl)
-        .get(`/layer/${layerName}/${LayerCacheType.S3}`)
-        .reply(200, { cacheName: 'cacheName', cache: { type: LayerCacheType.S3 } });
+      nock(baseUrl).get(`/layer/${layerName}/${LayerCacheType.S3}`).reply(200, cacheResponse);
 
-      const action = mapproxyApiClient.getS3CacheBucketName(layerName);
+      const action = mapproxyApiClient.getLayerCache(layerName);
 
-      await expect(action).resolves.toBeUndefined();
+      await expect(action).resolves.toEqual(cacheResponse);
     });
 
-    it('should return undefined when the layer s3 cache is not found (layer already removed)', async () => {
+    it('should return undefined when the layer cache is not found (layer already removed)', async () => {
       const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
       const layerName: LayerName = 'not_found-Orthophoto';
 
-      nock(baseUrl).get(`/layer/${layerName}/${LayerCacheType.S3}`).reply(404);
+      nock(baseUrl).get(`/layer/${layerName}/${LayerCacheType.FS}`).reply(404);
 
-      const action = mapproxyApiClient.getS3CacheBucketName(layerName);
+      const action = mapproxyApiClient.getLayerCache(layerName);
 
       await expect(action).resolves.toBeUndefined();
     });
@@ -208,9 +214,9 @@ describe('mapproxyClient', () => {
       const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
       const layerName: LayerName = 'error-Orthophoto';
 
-      nock(baseUrl).get(`/layer/${layerName}/${LayerCacheType.S3}`).reply(500);
+      nock(baseUrl).get(`/layer/${layerName}/${LayerCacheType.FS}`).reply(500);
 
-      const action = mapproxyApiClient.getS3CacheBucketName(layerName);
+      const action = mapproxyApiClient.getLayerCache(layerName);
 
       await expect(action).rejects.toThrow();
     });

--- a/tests/unit/httpClients/mapproxyClient.spec.ts
+++ b/tests/unit/httpClients/mapproxyClient.spec.ts
@@ -7,6 +7,7 @@ import { getTestLogger } from '../../configurations/testLogger';
 import { MapproxyApiClient } from '../../../src/httpClients/mapproxyClient';
 import { configMock, init as InitConfig, setValue, registerDefaultConfig } from '../mocks/configMock';
 import {
+  DeleteLayerError,
   LayerCacheNotFoundError,
   PublishLayerError,
   UnsupportedLayerCacheError,
@@ -158,6 +159,54 @@ describe('mapproxyClient', () => {
       const action = mapproxyApiClient.getCacheName({ layerName, cacheType });
 
       await expect(action).rejects.toThrow(LayerCacheNotFoundError);
+    });
+  });
+
+  describe('removeLayer', () => {
+    it('should remove a layer from mapproxy', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
+      const layerName = 'test_orthophoto';
+
+      nock(baseUrl).delete('/layer').query({ 'layerNames[]': layerName }).reply(200, []);
+
+      const action = mapproxyApiClient.removeLayer(layerName);
+
+      await expect(action).resolves.not.toThrow();
+      // eslint-disable-next-line import-x/no-named-as-default-member
+      expect(nock.isDone()).toBe(true);
+    });
+
+    it('should treat a 404 as success (idempotent re-run)', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
+      const layerName = 'already_removed_orthophoto';
+
+      nock(baseUrl).delete('/layer').query({ 'layerNames[]': layerName }).reply(404);
+
+      const action = mapproxyApiClient.removeLayer(layerName);
+
+      await expect(action).resolves.not.toThrow();
+    });
+
+    it('should throw DeleteLayerError when mapproxy reports the layer as failed', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
+      const layerName = 'failed_orthophoto';
+
+      nock(baseUrl).delete('/layer').query({ 'layerNames[]': layerName }).reply(200, [layerName]);
+
+      const action = mapproxyApiClient.removeLayer(layerName);
+
+      await expect(action).rejects.toThrow(DeleteLayerError);
+    });
+
+    it('should throw DeleteLayerError on a server error', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
+      const layerName = 'error_orthophoto';
+
+      nock(baseUrl).delete('/layer').query({ 'layerNames[]': layerName }).reply(500);
+
+      const action = mapproxyApiClient.removeLayer(layerName);
+
+      await expect(action).rejects.toThrow(DeleteLayerError);
     });
   });
 });

--- a/tests/unit/httpClients/mapproxyClient.spec.ts
+++ b/tests/unit/httpClients/mapproxyClient.spec.ts
@@ -115,7 +115,7 @@ describe('mapproxyClient', () => {
     });
   });
 
-  describe('getCacheName', () => {
+  describe('getRedisCacheName', () => {
     it('should get cache name from mapproxy', async () => {
       const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
       const layerName: LayerName = 'test-Orthophoto';
@@ -126,7 +126,7 @@ describe('mapproxyClient', () => {
         .get(`/layer/${layerName}/${cacheType}`)
         .reply(200, { cacheName, cache: { type: cacheType } });
 
-      const action = mapproxyApiClient.getCacheName({ layerName, cacheType });
+      const action = mapproxyApiClient.getRedisCacheName({ layerName, cacheType });
 
       await expect(action).resolves.not.toThrow();
       // eslint-disable-next-line import-x/no-named-as-default-member
@@ -144,7 +144,7 @@ describe('mapproxyClient', () => {
         .get(`/layer/${layerName}/${cacheType}`)
         .reply(200, { cacheName, cache: { type: cacheType } });
 
-      const action = mapproxyApiClient.getCacheName({ layerName, cacheType });
+      const action = mapproxyApiClient.getRedisCacheName({ layerName, cacheType });
 
       await expect(action).rejects.toThrow(UnsupportedLayerCacheError);
     });
@@ -156,7 +156,7 @@ describe('mapproxyClient', () => {
 
       nock(baseUrl).get(`/layer/${layerName}/${cacheType}`).reply(404);
 
-      const action = mapproxyApiClient.getCacheName({ layerName, cacheType });
+      const action = mapproxyApiClient.getRedisCacheName({ layerName, cacheType });
 
       await expect(action).rejects.toThrow(LayerCacheNotFoundError);
     });

--- a/tests/unit/httpClients/mapproxyClient.spec.ts
+++ b/tests/unit/httpClients/mapproxyClient.spec.ts
@@ -162,6 +162,60 @@ describe('mapproxyClient', () => {
     });
   });
 
+  describe('getS3CacheBucketName', () => {
+    it('should return the bucket name of the layer s3 cache', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
+      const layerName: LayerName = 'test-Orthophoto';
+      const bucketName = 'raster-tiles-bucket';
+
+      nock(baseUrl)
+        .get(`/layer/${layerName}/${LayerCacheType.S3}`)
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        .reply(200, { cacheName: 'cacheName', cache: { type: LayerCacheType.S3, bucket_name: bucketName } });
+
+      const action = mapproxyApiClient.getS3CacheBucketName(layerName);
+
+      await expect(action).resolves.toBe(bucketName);
+      // eslint-disable-next-line import-x/no-named-as-default-member
+      expect(nock.isDone()).toBe(true);
+    });
+
+    it('should return undefined when the cache has no bucket_name (global default bucket)', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
+      const layerName: LayerName = 'test-Orthophoto';
+
+      nock(baseUrl)
+        .get(`/layer/${layerName}/${LayerCacheType.S3}`)
+        .reply(200, { cacheName: 'cacheName', cache: { type: LayerCacheType.S3 } });
+
+      const action = mapproxyApiClient.getS3CacheBucketName(layerName);
+
+      await expect(action).resolves.toBeUndefined();
+    });
+
+    it('should return undefined when the layer s3 cache is not found (layer already removed)', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
+      const layerName: LayerName = 'not_found-Orthophoto';
+
+      nock(baseUrl).get(`/layer/${layerName}/${LayerCacheType.S3}`).reply(404);
+
+      const action = mapproxyApiClient.getS3CacheBucketName(layerName);
+
+      await expect(action).resolves.toBeUndefined();
+    });
+
+    it('should rethrow on a server error', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');
+      const layerName: LayerName = 'error-Orthophoto';
+
+      nock(baseUrl).get(`/layer/${layerName}/${LayerCacheType.S3}`).reply(500);
+
+      const action = mapproxyApiClient.getS3CacheBucketName(layerName);
+
+      await expect(action).rejects.toThrow();
+    });
+  });
+
   describe('removeLayer', () => {
     it('should remove a layer from mapproxy', async () => {
       const baseUrl = configMock.get<string>('servicesUrl.mapproxyApi');

--- a/tests/unit/httpClients/polygonPartMangerClient.spec.ts
+++ b/tests/unit/httpClients/polygonPartMangerClient.spec.ts
@@ -4,7 +4,7 @@ import nock from 'nock';
 import { getTestLogger } from '../../configurations/testLogger';
 import { PolygonPartsMangerClient } from '../../../src/httpClients/polygonPartsMangerClient';
 import { createFakeRoiFeatureCollection } from '../mocks/exportMockData';
-import { LayerMetadataAggregationError, PolygonPartsProcessingError } from '../../../src/common/errors';
+import { DeleteLayerError, LayerMetadataAggregationError, PolygonPartsProcessingError } from '../../../src/common/errors';
 import type { PolygonPartsProcessPayload } from '../../../src/common/interfaces';
 import { configMock, registerDefaultConfig } from '../mocks/configMock';
 import { createFakeAggregatedFeature } from './catalogClientSetup';
@@ -154,6 +154,43 @@ describe('polygonPartsManagerClient', () => {
       const action = polygonPartsManagerClient.getAggregatedLayerMetadata(polygonPartsEntityName, featureCollection);
 
       await expect(action).rejects.toThrow(LayerMetadataAggregationError);
+    });
+  });
+
+  describe('deleteEntities', () => {
+    it('should delete polygon parts entities from polygon parts manager', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.polygonPartsManager');
+      const polygonPartsEntityName = 'world_orthophoto';
+
+      nock(baseUrl).delete(`/polygonParts/${polygonPartsEntityName}`).reply(204);
+
+      const action = polygonPartsManagerClient.deleteEntities(polygonPartsEntityName);
+
+      await expect(action).resolves.not.toThrow();
+      // eslint-disable-next-line import-x/no-named-as-default-member
+      expect(nock.isDone()).toBe(true);
+    });
+
+    it('should treat a 404 as success (idempotent re-run)', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.polygonPartsManager');
+      const polygonPartsEntityName = 'already_gone_orthophoto';
+
+      nock(baseUrl).delete(`/polygonParts/${polygonPartsEntityName}`).reply(404);
+
+      const action = polygonPartsManagerClient.deleteEntities(polygonPartsEntityName);
+
+      await expect(action).resolves.not.toThrow();
+    });
+
+    it('should throw DeleteLayerError on a server error', async () => {
+      const baseUrl = configMock.get<string>('servicesUrl.polygonPartsManager');
+      const polygonPartsEntityName = 'error_test_orthophoto';
+
+      nock(baseUrl).delete(`/polygonParts/${polygonPartsEntityName}`).reply(500);
+
+      const action = polygonPartsManagerClient.deleteEntities(polygonPartsEntityName);
+
+      await expect(action).rejects.toThrow(DeleteLayerError);
     });
   });
 });

--- a/tests/unit/job/deleteLayerHandler/deleteLayerHandler.spec.ts
+++ b/tests/unit/job/deleteLayerHandler/deleteLayerHandler.spec.ts
@@ -100,8 +100,8 @@ describe('DeleteLayerHandler', () => {
 
   describe('tiles bucket resolution', () => {
     it('should not resolve a bucket for the FS provider', async () => {
-      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
       setValue('tilesStorageProvider', 'FS');
+      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
       const job = structuredClone(deleteLayerJob);
       const task = structuredClone(deleteTaskForDeleteLayer);
 
@@ -114,13 +114,13 @@ describe('DeleteLayerHandler', () => {
       expect(mapproxyClientMock.getS3CacheBucketName).not.toHaveBeenCalled();
       expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(
         job.id,
-        expect.objectContaining({ parameters: expect.objectContaining({ sourceProvider: 'FS', bucket: undefined }) })
+        expect.objectContaining({ parameters: { paths: [job.internalId], storageProvider: 'FS' } })
       );
     });
 
     it('should resolve the bucket from the mapproxy cache before the layer is removed (S3)', async () => {
-      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
       setValue('tilesStorageProvider', 'S3');
+      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
       const job = structuredClone(deleteLayerJob);
       const task = structuredClone(deleteTaskForDeleteLayer);
 
@@ -131,22 +131,24 @@ describe('DeleteLayerHandler', () => {
 
       await deleteLayerHandler.handleJobDelete(job, task);
 
-      // key design point: the cache must be read BEFORE removeLayer, after which getCache 404s
+      // key design point: the cache must be read BEFORE removeLayer
       expect(mapproxyClientMock.getS3CacheBucketName).toHaveBeenCalledTimes(1);
       expect(mapproxyClientMock.removeLayer).toHaveBeenCalledTimes(1);
+
       const cacheOrder = mapproxyClientMock.getS3CacheBucketName.mock.invocationCallOrder[0] ?? 0;
       const removeOrder = mapproxyClientMock.removeLayer.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER;
+
       expect(cacheOrder).toBeLessThan(removeOrder);
       expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(
         job.id,
-        expect.objectContaining({ parameters: expect.objectContaining({ sourceProvider: 'S3', bucket: 'mapproxy-cache-bucket' }) })
+        expect.objectContaining({ parameters: { paths: [job.internalId], storageProvider: 'S3', bucket: 'mapproxy-cache-bucket' } })
       );
     });
 
     it('should fall back to the configured tiles bucket when mapproxy cannot resolve it (S3)', async () => {
-      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
       setValue('tilesStorageProvider', 'S3');
       setValue('S3.tilesBucket', 'config-fallback-bucket');
+      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
       const job = structuredClone(deleteLayerJob);
       const task = structuredClone(deleteTaskForDeleteLayer);
 
@@ -159,7 +161,7 @@ describe('DeleteLayerHandler', () => {
 
       expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(
         job.id,
-        expect.objectContaining({ parameters: expect.objectContaining({ sourceProvider: 'S3', bucket: 'config-fallback-bucket' }) })
+        expect.objectContaining({ parameters: { paths: [job.internalId], storageProvider: 'S3', bucket: 'config-fallback-bucket' } })
       );
     });
   });

--- a/tests/unit/job/deleteLayerHandler/deleteLayerHandler.spec.ts
+++ b/tests/unit/job/deleteLayerHandler/deleteLayerHandler.spec.ts
@@ -1,15 +1,37 @@
 /* eslint-disable @typescript-eslint/unbound-method */
+/* eslint-disable @typescript-eslint/naming-convention */
 import { getEntityName } from '@map-colonies/raster-shared';
+import type { GetMapproxyCacheResponse } from '../../../../src/common/interfaces';
+import { LayerCacheType } from '../../../../src/common/constants';
 import { registerDefaultConfig, setValue } from '../../mocks/configMock';
 import { deleteLayerJob } from '../../mocks/jobsMockData';
 import { deleteTaskForDeleteLayer } from '../../mocks/tasksMockData';
-import { jobTrackerClientMock } from '../../mocks/jobManagerMocks';
 import { setupDeleteLayerHandlerTest } from './deleteLayerHandlerSetup';
 
 describe('DeleteLayerHandler', () => {
   const layerName = `${deleteLayerJob.resourceId}-${deleteLayerJob.productType}`;
   const entityName = getEntityName(deleteLayerJob.resourceId, deleteLayerJob.productType);
   const tilesDeletionType = 'tiles-deletion';
+
+  const fsCacheResponse: GetMapproxyCacheResponse = {
+    cacheName: layerName,
+    cache: {
+      type: LayerCacheType.FS,
+      directory: '/outputs/3460db6b-ef85-4871-9aae-ca42fac1edca/8fec1314-dc3e-43d7-9d8a-b056b1eb9771/',
+      directory_layout: 'tms',
+    },
+  };
+  const fsRelativePath = '3460db6b-ef85-4871-9aae-ca42fac1edca/8fec1314-dc3e-43d7-9d8a-b056b1eb9771/';
+
+  const s3CacheResponse: GetMapproxyCacheResponse = {
+    cacheName: layerName,
+    cache: {
+      type: LayerCacheType.S3,
+      directory: '/5eedfc75-861c-42fc-81a9-ab2c0b95c274/d8527f15-5377-4a28-b5ce-92891d897aec/',
+      directory_layout: 'tms',
+    },
+  };
+  const s3KeyPrefix = '5eedfc75-861c-42fc-81a9-ab2c0b95c274/d8527f15-5377-4a28-b5ce-92891d897aec/';
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -30,6 +52,7 @@ describe('DeleteLayerHandler', () => {
       const job = structuredClone(deleteLayerJob);
       const task = structuredClone(deleteTaskForDeleteLayer);
 
+      mapproxyClientMock.getLayerCache.mockResolvedValue(fsCacheResponse);
       jobManagerClientMock.updateTask.mockResolvedValue(undefined);
       jobManagerClientMock.findTasks.mockResolvedValue([]);
       jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
@@ -44,8 +67,17 @@ describe('DeleteLayerHandler', () => {
       expect(polygonPartsManagerClientMock.deleteEntities).toHaveBeenCalledWith(entityName);
       expect(mapproxyClientMock.removeLayer).toHaveBeenCalledWith(layerName);
 
-      // each step persisted immediately (§4.2, §6)
-      expect(jobManagerClientMock.updateTask).toHaveBeenCalledTimes(4);
+      // tiles location persisted first, then each step persisted immediately (§4.2, §6)
+      expect(jobManagerClientMock.updateTask).toHaveBeenCalledTimes(5);
+      expect(jobManagerClientMock.updateTask).toHaveBeenNthCalledWith(1, job.id, task.id, {
+        parameters: {
+          deleteFromCatalog: false,
+          deleteFromGeoserver: false,
+          deletePolygonParts: false,
+          deleteFromMapproxy: false,
+          tilesLocation: { path: fsRelativePath },
+        },
+      });
       expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(job.id, expect.objectContaining({ type: tilesDeletionType }));
       expect(completeTaskSpy).toHaveBeenCalledWith(job, task, expect.any(Object));
       expect(queueClientMock.ack).toHaveBeenCalledWith(job.id, task.id);
@@ -56,7 +88,13 @@ describe('DeleteLayerHandler', () => {
         await setupDeleteLayerHandlerTest();
       const job = structuredClone(deleteLayerJob);
       const task = structuredClone(deleteTaskForDeleteLayer);
-      task.parameters = { deleteFromCatalog: true, deleteFromGeoserver: true, deletePolygonParts: false, deleteFromMapproxy: false };
+      task.parameters = {
+        deleteFromCatalog: true,
+        deleteFromGeoserver: true,
+        deletePolygonParts: false,
+        deleteFromMapproxy: false,
+        tilesLocation: { path: fsRelativePath },
+      };
 
       jobManagerClientMock.updateTask.mockResolvedValue(undefined);
       jobManagerClientMock.findTasks.mockResolvedValue([]);
@@ -76,6 +114,7 @@ describe('DeleteLayerHandler', () => {
       const job = structuredClone(deleteLayerJob);
       const task = structuredClone(deleteTaskForDeleteLayer);
       // mapproxy step throws before completion, so not all steps complete
+      mapproxyClientMock.getLayerCache.mockResolvedValue(fsCacheResponse);
       mapproxyClientMock.removeLayer.mockRejectedValue(new Error('mapproxy down'));
 
       await deleteLayerHandler.handleJobDelete(job, task);
@@ -84,11 +123,12 @@ describe('DeleteLayerHandler', () => {
     });
 
     it('should reject the task when a deletion step fails', async () => {
-      const { deleteLayerHandler, queueClientMock, catalogClientMock } = await setupDeleteLayerHandlerTest();
+      const { deleteLayerHandler, queueClientMock, catalogClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
       const job = structuredClone(deleteLayerJob);
       const task = structuredClone(deleteTaskForDeleteLayer);
       const error = new Error('catalog unreachable');
 
+      mapproxyClientMock.getLayerCache.mockResolvedValue(fsCacheResponse);
       catalogClientMock.deleteRecord.mockRejectedValue(error);
       queueClientMock.reject.mockResolvedValue(undefined);
 
@@ -98,33 +138,14 @@ describe('DeleteLayerHandler', () => {
     });
   });
 
-  describe('tiles bucket resolution', () => {
-    it('should not resolve a bucket for the FS provider', async () => {
-      setValue('tilesStorageProvider', 'FS');
-      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
-      const job = structuredClone(deleteLayerJob);
-      const task = structuredClone(deleteTaskForDeleteLayer);
-
-      jobManagerClientMock.updateTask.mockResolvedValue(undefined);
-      jobManagerClientMock.findTasks.mockResolvedValue([]);
-      jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
-
-      await deleteLayerHandler.handleJobDelete(job, task);
-
-      expect(mapproxyClientMock.getS3CacheBucketName).not.toHaveBeenCalled();
-      expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(
-        job.id,
-        expect.objectContaining({ parameters: { paths: [job.internalId], storageProvider: 'FS' } })
-      );
-    });
-
-    it('should resolve the bucket from the mapproxy cache before the layer is removed (S3)', async () => {
+  describe('tiles location resolution', () => {
+    it('should resolve the tiles location from the mapproxy cache before the layer is removed', async () => {
       setValue('tilesStorageProvider', 'S3');
       const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
       const job = structuredClone(deleteLayerJob);
       const task = structuredClone(deleteTaskForDeleteLayer);
 
-      mapproxyClientMock.getS3CacheBucketName.mockResolvedValue('mapproxy-cache-bucket');
+      mapproxyClientMock.getLayerCache.mockResolvedValue(s3CacheResponse);
       jobManagerClientMock.updateTask.mockResolvedValue(undefined);
       jobManagerClientMock.findTasks.mockResolvedValue([]);
       jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
@@ -132,27 +153,22 @@ describe('DeleteLayerHandler', () => {
       await deleteLayerHandler.handleJobDelete(job, task);
 
       // key design point: the cache must be read BEFORE removeLayer
-      expect(mapproxyClientMock.getS3CacheBucketName).toHaveBeenCalledTimes(1);
+      expect(mapproxyClientMock.getLayerCache).toHaveBeenCalledTimes(1);
       expect(mapproxyClientMock.removeLayer).toHaveBeenCalledTimes(1);
 
-      const cacheOrder = mapproxyClientMock.getS3CacheBucketName.mock.invocationCallOrder[0] ?? 0;
+      const cacheOrder = mapproxyClientMock.getLayerCache.mock.invocationCallOrder[0] ?? 0;
       const removeOrder = mapproxyClientMock.removeLayer.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER;
 
       expect(cacheOrder).toBeLessThan(removeOrder);
-      expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(
-        job.id,
-        expect.objectContaining({ parameters: { paths: [job.internalId], storageProvider: 'S3', bucket: 'mapproxy-cache-bucket' } })
-      );
     });
 
-    it('should fall back to the configured tiles bucket when mapproxy cannot resolve it (S3)', async () => {
-      setValue('tilesStorageProvider', 'S3');
-      setValue('S3.tilesBucket', 'config-fallback-bucket');
+    it('should pass the FS cache directory relative to the mount path (first folder stripped) without a bucket', async () => {
+      setValue('tilesStorageProvider', 'FS');
       const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
       const job = structuredClone(deleteLayerJob);
       const task = structuredClone(deleteTaskForDeleteLayer);
 
-      mapproxyClientMock.getS3CacheBucketName.mockResolvedValue(undefined);
+      mapproxyClientMock.getLayerCache.mockResolvedValue(fsCacheResponse);
       jobManagerClientMock.updateTask.mockResolvedValue(undefined);
       jobManagerClientMock.findTasks.mockResolvedValue([]);
       jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
@@ -161,17 +177,103 @@ describe('DeleteLayerHandler', () => {
 
       expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(
         job.id,
-        expect.objectContaining({ parameters: { paths: [job.internalId], storageProvider: 'S3', bucket: 'config-fallback-bucket' } })
+        expect.objectContaining({ parameters: { paths: [fsRelativePath], storageProvider: 'FS' } })
       );
+    });
+
+    it('should pass the S3 cache directory as a key prefix (leading slash stripped) with the cache bucket', async () => {
+      setValue('tilesStorageProvider', 'S3');
+      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
+      const job = structuredClone(deleteLayerJob);
+      const task = structuredClone(deleteTaskForDeleteLayer);
+
+      mapproxyClientMock.getLayerCache.mockResolvedValue({
+        ...s3CacheResponse,
+        cache: { ...s3CacheResponse.cache, bucket_name: 'mapproxy-cache-bucket' },
+      });
+      jobManagerClientMock.updateTask.mockResolvedValue(undefined);
+      jobManagerClientMock.findTasks.mockResolvedValue([]);
+      jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
+
+      await deleteLayerHandler.handleJobDelete(job, task);
+
+      expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(
+        job.id,
+        expect.objectContaining({ parameters: { paths: [s3KeyPrefix], storageProvider: 'S3', bucket: 'mapproxy-cache-bucket' } })
+      );
+    });
+
+    it('should fall back to the configured tiles bucket when the cache has no bucket_name (S3)', async () => {
+      setValue('tilesStorageProvider', 'S3');
+      setValue('S3.tilesBucket', 'config-fallback-bucket');
+      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
+      const job = structuredClone(deleteLayerJob);
+      const task = structuredClone(deleteTaskForDeleteLayer);
+
+      mapproxyClientMock.getLayerCache.mockResolvedValue(s3CacheResponse);
+      jobManagerClientMock.updateTask.mockResolvedValue(undefined);
+      jobManagerClientMock.findTasks.mockResolvedValue([]);
+      jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
+
+      await deleteLayerHandler.handleJobDelete(job, task);
+
+      expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(
+        job.id,
+        expect.objectContaining({ parameters: { paths: [s3KeyPrefix], storageProvider: 'S3', bucket: 'config-fallback-bucket' } })
+      );
+    });
+
+    it('should use the persisted tiles location on a redelivered task without querying mapproxy', async () => {
+      setValue('tilesStorageProvider', 'S3');
+      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
+      const job = structuredClone(deleteLayerJob);
+      const task = structuredClone(deleteTaskForDeleteLayer);
+      // all metadata steps already done; the mapproxy layer (and its cache) is gone
+      task.parameters = {
+        deleteFromCatalog: true,
+        deleteFromGeoserver: true,
+        deletePolygonParts: true,
+        deleteFromMapproxy: true,
+        tilesLocation: { path: s3KeyPrefix, bucket: 'persisted-bucket' },
+      };
+
+      jobManagerClientMock.findTasks.mockResolvedValue([]);
+      jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
+
+      await deleteLayerHandler.handleJobDelete(job, task);
+
+      expect(mapproxyClientMock.getLayerCache).not.toHaveBeenCalled();
+      expect(jobManagerClientMock.updateTask).not.toHaveBeenCalled();
+      expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(
+        job.id,
+        expect.objectContaining({ parameters: { paths: [s3KeyPrefix], storageProvider: 'S3', bucket: 'persisted-bucket' } })
+      );
+    });
+
+    it('should reject the task without running any deletion step when the tiles location cannot be resolved', async () => {
+      const { deleteLayerHandler, queueClientMock, jobManagerClientMock, catalogClientMock, mapproxyClientMock } =
+        await setupDeleteLayerHandlerTest();
+      const job = structuredClone(deleteLayerJob);
+      const task = structuredClone(deleteTaskForDeleteLayer);
+
+      mapproxyClientMock.getLayerCache.mockResolvedValue(undefined);
+      queueClientMock.reject.mockResolvedValue(undefined);
+
+      await deleteLayerHandler.handleJobDelete(job, task);
+
+      expect(catalogClientMock.deleteRecord).not.toHaveBeenCalled();
+      expect(jobManagerClientMock.updateTask).not.toHaveBeenCalled();
+      expect(queueClientMock.reject).toHaveBeenCalledWith(job.id, task.id, true, expect.stringContaining(layerName));
     });
   });
 
   describe('cleaner task idempotency', () => {
     it('should not create a duplicate tiles-deletion task when one already exists', async () => {
-      const { deleteLayerHandler, jobManagerClientMock } = await setupDeleteLayerHandlerTest();
+      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
       const job = structuredClone(deleteLayerJob);
       const task = structuredClone(deleteTaskForDeleteLayer);
 
+      mapproxyClientMock.getLayerCache.mockResolvedValue(fsCacheResponse);
       jobManagerClientMock.updateTask.mockResolvedValue(undefined);
       jobManagerClientMock.findTasks.mockResolvedValue([{ id: 'existing-tiles-task' }] as never);
 

--- a/tests/unit/job/deleteLayerHandler/deleteLayerHandler.spec.ts
+++ b/tests/unit/job/deleteLayerHandler/deleteLayerHandler.spec.ts
@@ -1,0 +1,182 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { getEntityName } from '@map-colonies/raster-shared';
+import { registerDefaultConfig, setValue } from '../../mocks/configMock';
+import { deleteLayerJob } from '../../mocks/jobsMockData';
+import { deleteTaskForDeleteLayer } from '../../mocks/tasksMockData';
+import { jobTrackerClientMock } from '../../mocks/jobManagerMocks';
+import { setupDeleteLayerHandlerTest } from './deleteLayerHandlerSetup';
+
+describe('DeleteLayerHandler', () => {
+  const layerName = `${deleteLayerJob.resourceId}-${deleteLayerJob.productType}`;
+  const entityName = getEntityName(deleteLayerJob.resourceId, deleteLayerJob.productType);
+  const tilesDeletionType = 'tiles-deletion';
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    registerDefaultConfig();
+  });
+
+  describe('handleJobDelete', () => {
+    it('should run all metadata deletion steps in order, mark each, then create cleaner tasks and complete', async () => {
+      const {
+        deleteLayerHandler,
+        queueClientMock,
+        jobManagerClientMock,
+        catalogClientMock,
+        geoserverClientMock,
+        polygonPartsManagerClientMock,
+        mapproxyClientMock,
+      } = await setupDeleteLayerHandlerTest();
+      const job = structuredClone(deleteLayerJob);
+      const task = structuredClone(deleteTaskForDeleteLayer);
+
+      jobManagerClientMock.updateTask.mockResolvedValue(undefined);
+      jobManagerClientMock.findTasks.mockResolvedValue([]);
+      jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
+      queueClientMock.ack.mockResolvedValue(undefined);
+
+      const completeTaskSpy = vi.spyOn(deleteLayerHandler as unknown as { completeTask: (...args: unknown[]) => unknown }, 'completeTask');
+
+      await deleteLayerHandler.handleJobDelete(job, task);
+
+      expect(catalogClientMock.deleteRecord).toHaveBeenCalledWith(job.internalId);
+      expect(geoserverClientMock.unpublishLayer).toHaveBeenCalledWith(layerName);
+      expect(polygonPartsManagerClientMock.deleteEntities).toHaveBeenCalledWith(entityName);
+      expect(mapproxyClientMock.removeLayer).toHaveBeenCalledWith(layerName);
+
+      // each step persisted immediately (§4.2, §6)
+      expect(jobManagerClientMock.updateTask).toHaveBeenCalledTimes(4);
+      expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(job.id, expect.objectContaining({ type: tilesDeletionType }));
+      expect(completeTaskSpy).toHaveBeenCalledWith(job, task, expect.any(Object));
+      expect(queueClientMock.ack).toHaveBeenCalledWith(job.id, task.id);
+    });
+
+    it('should skip steps already marked completed on a redelivered task', async () => {
+      const { deleteLayerHandler, jobManagerClientMock, catalogClientMock, geoserverClientMock, polygonPartsManagerClientMock, mapproxyClientMock } =
+        await setupDeleteLayerHandlerTest();
+      const job = structuredClone(deleteLayerJob);
+      const task = structuredClone(deleteTaskForDeleteLayer);
+      task.parameters = { deleteFromCatalog: true, deleteFromGeoserver: true, deletePolygonParts: false, deleteFromMapproxy: false };
+
+      jobManagerClientMock.updateTask.mockResolvedValue(undefined);
+      jobManagerClientMock.findTasks.mockResolvedValue([]);
+      jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
+
+      await deleteLayerHandler.handleJobDelete(job, task);
+
+      expect(catalogClientMock.deleteRecord).not.toHaveBeenCalled();
+      expect(geoserverClientMock.unpublishLayer).not.toHaveBeenCalled();
+      expect(polygonPartsManagerClientMock.deleteEntities).toHaveBeenCalledWith(entityName);
+      expect(mapproxyClientMock.removeLayer).toHaveBeenCalledWith(layerName);
+      expect(jobManagerClientMock.updateTask).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not create cleaner tasks until all steps are completed', async () => {
+      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
+      const job = structuredClone(deleteLayerJob);
+      const task = structuredClone(deleteTaskForDeleteLayer);
+      // mapproxy step throws before completion, so not all steps complete
+      mapproxyClientMock.removeLayer.mockRejectedValue(new Error('mapproxy down'));
+
+      await deleteLayerHandler.handleJobDelete(job, task);
+
+      expect(jobManagerClientMock.createTaskForJob).not.toHaveBeenCalled();
+    });
+
+    it('should reject the task when a deletion step fails', async () => {
+      const { deleteLayerHandler, queueClientMock, catalogClientMock } = await setupDeleteLayerHandlerTest();
+      const job = structuredClone(deleteLayerJob);
+      const task = structuredClone(deleteTaskForDeleteLayer);
+      const error = new Error('catalog unreachable');
+
+      catalogClientMock.deleteRecord.mockRejectedValue(error);
+      queueClientMock.reject.mockResolvedValue(undefined);
+
+      await deleteLayerHandler.handleJobDelete(job, task);
+
+      expect(queueClientMock.reject).toHaveBeenCalledWith(job.id, task.id, true, error.message);
+    });
+  });
+
+  describe('tiles bucket resolution', () => {
+    it('should not resolve a bucket for the FS provider', async () => {
+      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
+      setValue('tilesStorageProvider', 'FS');
+      const job = structuredClone(deleteLayerJob);
+      const task = structuredClone(deleteTaskForDeleteLayer);
+
+      jobManagerClientMock.updateTask.mockResolvedValue(undefined);
+      jobManagerClientMock.findTasks.mockResolvedValue([]);
+      jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
+
+      await deleteLayerHandler.handleJobDelete(job, task);
+
+      expect(mapproxyClientMock.getS3CacheBucketName).not.toHaveBeenCalled();
+      expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(
+        job.id,
+        expect.objectContaining({ parameters: expect.objectContaining({ sourceProvider: 'FS', bucket: undefined }) })
+      );
+    });
+
+    it('should resolve the bucket from the mapproxy cache before the layer is removed (S3)', async () => {
+      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
+      setValue('tilesStorageProvider', 'S3');
+      const job = structuredClone(deleteLayerJob);
+      const task = structuredClone(deleteTaskForDeleteLayer);
+
+      mapproxyClientMock.getS3CacheBucketName.mockResolvedValue('mapproxy-cache-bucket');
+      jobManagerClientMock.updateTask.mockResolvedValue(undefined);
+      jobManagerClientMock.findTasks.mockResolvedValue([]);
+      jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
+
+      await deleteLayerHandler.handleJobDelete(job, task);
+
+      // key design point: the cache must be read BEFORE removeLayer, after which getCache 404s
+      expect(mapproxyClientMock.getS3CacheBucketName).toHaveBeenCalledTimes(1);
+      expect(mapproxyClientMock.removeLayer).toHaveBeenCalledTimes(1);
+      const cacheOrder = mapproxyClientMock.getS3CacheBucketName.mock.invocationCallOrder[0] ?? 0;
+      const removeOrder = mapproxyClientMock.removeLayer.mock.invocationCallOrder[0] ?? Number.MAX_SAFE_INTEGER;
+      expect(cacheOrder).toBeLessThan(removeOrder);
+      expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(
+        job.id,
+        expect.objectContaining({ parameters: expect.objectContaining({ sourceProvider: 'S3', bucket: 'mapproxy-cache-bucket' }) })
+      );
+    });
+
+    it('should fall back to the configured tiles bucket when mapproxy cannot resolve it (S3)', async () => {
+      const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
+      setValue('tilesStorageProvider', 'S3');
+      setValue('S3.tilesBucket', 'config-fallback-bucket');
+      const job = structuredClone(deleteLayerJob);
+      const task = structuredClone(deleteTaskForDeleteLayer);
+
+      mapproxyClientMock.getS3CacheBucketName.mockResolvedValue(undefined);
+      jobManagerClientMock.updateTask.mockResolvedValue(undefined);
+      jobManagerClientMock.findTasks.mockResolvedValue([]);
+      jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
+
+      await deleteLayerHandler.handleJobDelete(job, task);
+
+      expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(
+        job.id,
+        expect.objectContaining({ parameters: expect.objectContaining({ sourceProvider: 'S3', bucket: 'config-fallback-bucket' }) })
+      );
+    });
+  });
+
+  describe('cleaner task idempotency', () => {
+    it('should not create a duplicate tiles-deletion task when one already exists', async () => {
+      const { deleteLayerHandler, jobManagerClientMock } = await setupDeleteLayerHandlerTest();
+      const job = structuredClone(deleteLayerJob);
+      const task = structuredClone(deleteTaskForDeleteLayer);
+
+      jobManagerClientMock.updateTask.mockResolvedValue(undefined);
+      jobManagerClientMock.findTasks.mockResolvedValue([{ id: 'existing-tiles-task' }] as never);
+
+      await deleteLayerHandler.handleJobDelete(job, task);
+
+      expect(jobManagerClientMock.findTasks).toHaveBeenCalledWith({ jobId: job.id, type: tilesDeletionType });
+      expect(jobManagerClientMock.createTaskForJob).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/tests/unit/job/deleteLayerHandler/deleteLayerHandler.spec.ts
+++ b/tests/unit/job/deleteLayerHandler/deleteLayerHandler.spec.ts
@@ -54,7 +54,6 @@ describe('DeleteLayerHandler', () => {
 
       mapproxyClientMock.getLayerCache.mockResolvedValue(fsCacheResponse);
       jobManagerClientMock.updateTask.mockResolvedValue(undefined);
-      jobManagerClientMock.findTasks.mockResolvedValue([]);
       jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
       queueClientMock.ack.mockResolvedValue(undefined);
 
@@ -97,7 +96,6 @@ describe('DeleteLayerHandler', () => {
       };
 
       jobManagerClientMock.updateTask.mockResolvedValue(undefined);
-      jobManagerClientMock.findTasks.mockResolvedValue([]);
       jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
 
       await deleteLayerHandler.handleJobDelete(job, task);
@@ -147,7 +145,6 @@ describe('DeleteLayerHandler', () => {
 
       mapproxyClientMock.getLayerCache.mockResolvedValue(s3CacheResponse);
       jobManagerClientMock.updateTask.mockResolvedValue(undefined);
-      jobManagerClientMock.findTasks.mockResolvedValue([]);
       jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
 
       await deleteLayerHandler.handleJobDelete(job, task);
@@ -170,7 +167,6 @@ describe('DeleteLayerHandler', () => {
 
       mapproxyClientMock.getLayerCache.mockResolvedValue(fsCacheResponse);
       jobManagerClientMock.updateTask.mockResolvedValue(undefined);
-      jobManagerClientMock.findTasks.mockResolvedValue([]);
       jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
 
       await deleteLayerHandler.handleJobDelete(job, task);
@@ -192,7 +188,6 @@ describe('DeleteLayerHandler', () => {
         cache: { ...s3CacheResponse.cache, bucket_name: 'mapproxy-cache-bucket' },
       });
       jobManagerClientMock.updateTask.mockResolvedValue(undefined);
-      jobManagerClientMock.findTasks.mockResolvedValue([]);
       jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
 
       await deleteLayerHandler.handleJobDelete(job, task);
@@ -212,7 +207,6 @@ describe('DeleteLayerHandler', () => {
 
       mapproxyClientMock.getLayerCache.mockResolvedValue(s3CacheResponse);
       jobManagerClientMock.updateTask.mockResolvedValue(undefined);
-      jobManagerClientMock.findTasks.mockResolvedValue([]);
       jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
 
       await deleteLayerHandler.handleJobDelete(job, task);
@@ -237,7 +231,6 @@ describe('DeleteLayerHandler', () => {
         tilesLocation: { path: s3KeyPrefix, bucket: 'persisted-bucket' },
       };
 
-      jobManagerClientMock.findTasks.mockResolvedValue([]);
       jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
 
       await deleteLayerHandler.handleJobDelete(job, task);
@@ -268,19 +261,21 @@ describe('DeleteLayerHandler', () => {
   });
 
   describe('cleaner task idempotency', () => {
-    it('should not create a duplicate tiles-deletion task when one already exists', async () => {
+    it('should prevent duplicate tasks from being created', async () => {
       const { deleteLayerHandler, jobManagerClientMock, mapproxyClientMock } = await setupDeleteLayerHandlerTest();
       const job = structuredClone(deleteLayerJob);
       const task = structuredClone(deleteTaskForDeleteLayer);
 
       mapproxyClientMock.getLayerCache.mockResolvedValue(fsCacheResponse);
       jobManagerClientMock.updateTask.mockResolvedValue(undefined);
-      jobManagerClientMock.findTasks.mockResolvedValue([{ id: 'existing-tiles-task' }] as never);
+      jobManagerClientMock.createTaskForJob.mockResolvedValue(undefined);
 
       await deleteLayerHandler.handleJobDelete(job, task);
 
-      expect(jobManagerClientMock.findTasks).toHaveBeenCalledWith({ jobId: job.id, type: tilesDeletionType });
-      expect(jobManagerClientMock.createTaskForJob).not.toHaveBeenCalled();
+      expect(jobManagerClientMock.createTaskForJob).toHaveBeenCalledWith(
+        job.id,
+        expect.objectContaining({ type: tilesDeletionType, blockDuplication: true })
+      );
     });
   });
 });

--- a/tests/unit/job/deleteLayerHandler/deleteLayerHandlerSetup.ts
+++ b/tests/unit/job/deleteLayerHandler/deleteLayerHandlerSetup.ts
@@ -1,0 +1,55 @@
+import type { Mocked } from 'vitest';
+import type { JobManagerClient, TaskHandler as QueueClient } from '@map-colonies/mc-priority-queue';
+import { getTestLogger } from '../../../configurations/testLogger';
+import type { MapproxyApiClient } from '../../../../src/httpClients/mapproxyClient';
+import type { CatalogClient } from '../../../../src/httpClients/catalogClient';
+import type { GeoserverClient } from '../../../../src/httpClients/geoserverClient';
+import type { PolygonPartsMangerClient } from '../../../../src/httpClients/polygonPartsMangerClient';
+import type { JobTrackerClient } from '../../../../src/httpClients/jobTrackerClient';
+import { DeleteLayerHandler } from '../../../../src/job/models/deletion/deleteLayerHandler';
+import { taskMetricsMock } from '../../mocks/metricsMock';
+import { jobManagerClientMock, jobTrackerClientMock, queueClientMock } from '../../mocks/jobManagerMocks';
+import { tracerMock } from '../../mocks/tracerMock';
+import { configMock } from '../../mocks/configMock';
+import { polygonPartsManagerClientMock } from '../../mocks/polygonPartsManagerClientMock';
+
+export interface DeleteLayerHandlerTestContext {
+  deleteLayerHandler: DeleteLayerHandler;
+  queueClientMock: Mocked<QueueClient>;
+  jobManagerClientMock: Mocked<JobManagerClient>;
+  catalogClientMock: Mocked<CatalogClient>;
+  geoserverClientMock: Mocked<GeoserverClient>;
+  polygonPartsManagerClientMock: Mocked<PolygonPartsMangerClient>;
+  mapproxyClientMock: Mocked<MapproxyApiClient>;
+  jobTrackerClientMock: Mocked<JobTrackerClient>;
+}
+
+export const setupDeleteLayerHandlerTest = async (): Promise<DeleteLayerHandlerTestContext> => {
+  const catalogClientMock = { deleteRecord: vi.fn() } as unknown as Mocked<CatalogClient>;
+  const geoserverClientMock = { unpublishLayer: vi.fn() } as unknown as Mocked<GeoserverClient>;
+  const mapproxyClientMock = { removeLayer: vi.fn(), getS3CacheBucketName: vi.fn() } as unknown as Mocked<MapproxyApiClient>;
+
+  const deleteLayerHandler = new DeleteLayerHandler(
+    await getTestLogger(),
+    configMock,
+    tracerMock,
+    queueClientMock,
+    catalogClientMock,
+    geoserverClientMock,
+    polygonPartsManagerClientMock,
+    mapproxyClientMock,
+    jobTrackerClientMock,
+    taskMetricsMock
+  );
+
+  return {
+    deleteLayerHandler,
+    queueClientMock,
+    jobManagerClientMock,
+    catalogClientMock,
+    geoserverClientMock,
+    polygonPartsManagerClientMock,
+    mapproxyClientMock,
+    jobTrackerClientMock,
+  };
+};

--- a/tests/unit/job/deleteLayerHandler/deleteLayerHandlerSetup.ts
+++ b/tests/unit/job/deleteLayerHandler/deleteLayerHandlerSetup.ts
@@ -27,7 +27,7 @@ export interface DeleteLayerHandlerTestContext {
 export const setupDeleteLayerHandlerTest = async (): Promise<DeleteLayerHandlerTestContext> => {
   const catalogClientMock = { deleteRecord: vi.fn() } as unknown as Mocked<CatalogClient>;
   const geoserverClientMock = { unpublishLayer: vi.fn() } as unknown as Mocked<GeoserverClient>;
-  const mapproxyClientMock = { removeLayer: vi.fn(), getS3CacheBucketName: vi.fn() } as unknown as Mocked<MapproxyApiClient>;
+  const mapproxyClientMock = { removeLayer: vi.fn(), getLayerCache: vi.fn() } as unknown as Mocked<MapproxyApiClient>;
 
   const deleteLayerHandler = new DeleteLayerHandler(
     await getTestLogger(),

--- a/tests/unit/job/jobProcessor/JobProcessor.spec.ts
+++ b/tests/unit/job/jobProcessor/JobProcessor.spec.ts
@@ -1,11 +1,12 @@
 import type { Mocked } from 'vitest';
 import nock, { cleanAll, emitter } from 'nock';
+import { OperationStatus } from '@map-colonies/mc-priority-queue';
 import type { IJobHandler, JobAndTaskResponse, PollingConfig, JobManagementConfig } from '../../../../src/common/interfaces';
 import { getPollingJobs, parseInstanceType } from '../../../../src/utils/configUtil';
 import type { InstanceType } from '../../../../src/utils/zod/schemas/instance.schema';
 import { jobTaskSchemaMap, type OperationValidationKey } from '../../../../src/utils/zod/schemas/job.schema';
 import { registerDefaultConfig, setValue } from '../../mocks/configMock';
-import { createTasksTestCases, finalizeTestCases } from '../../mocks/testCasesData';
+import { createTasksTestCases, deleteTestCases, finalizeTestCases } from '../../mocks/testCasesData';
 import type { JobProcessorTestContext } from './jobProcessorSetup';
 import { setupJobProcessorTest } from './jobProcessorSetup';
 
@@ -299,6 +300,52 @@ describe('JobProcessor', () => {
 
       await expect(jobProcessor['getJobAndTaskResponse']()).rejects.toThrow('Request failed with status code 500');
       expect(dequeueSpy).toHaveBeenCalledWith(jobType, taskType);
+    });
+  });
+
+  describe('getJob', () => {
+    it('should update job status to IN_PROGRESS when task type is init', async () => {
+      const { jobProcessor, mockGetJob, mockUpdateJob, configMock } = testContext;
+      const { tasks } = configMock.get<PollingConfig>('jobManagement.polling');
+      const job = createTasksTestCases[3]!.job; // export init job
+
+      mockGetJob.mockResolvedValueOnce(job);
+      mockUpdateJob.mockResolvedValueOnce(undefined);
+
+      const result = await jobProcessor['getJob'](job.id, tasks.init);
+
+      expect(mockGetJob).toHaveBeenCalledWith(job.id);
+      expect(mockUpdateJob).toHaveBeenCalledWith(job.id, { status: OperationStatus.IN_PROGRESS });
+      expect(result).toEqual(job);
+    });
+
+    it('should update job status to IN_PROGRESS when task type is delete', async () => {
+      const { jobProcessor, mockGetJob, mockUpdateJob, configMock } = testContext;
+      const { tasks } = configMock.get<PollingConfig>('jobManagement.polling');
+      const job = deleteTestCases[0]!.job;
+
+      mockGetJob.mockResolvedValueOnce(job);
+      mockUpdateJob.mockResolvedValueOnce(undefined);
+
+      const result = await jobProcessor['getJob'](job.id, tasks.delete);
+
+      expect(mockGetJob).toHaveBeenCalledWith(job.id);
+      expect(mockUpdateJob).toHaveBeenCalledWith(job.id, { status: OperationStatus.IN_PROGRESS });
+      expect(result).toEqual(job);
+    });
+
+    it('should not update job status when task type is neither init nor delete', async () => {
+      const { jobProcessor, mockGetJob, mockUpdateJob, configMock } = testContext;
+      const { tasks } = configMock.get<PollingConfig>('jobManagement.polling');
+      const job = createTasksTestCases[0]!.job;
+
+      mockGetJob.mockResolvedValueOnce(job);
+
+      const result = await jobProcessor['getJob'](job.id, tasks.finalize);
+
+      expect(mockGetJob).toHaveBeenCalledWith(job.id);
+      expect(mockUpdateJob).not.toHaveBeenCalled();
+      expect(result).toEqual(job);
     });
   });
 

--- a/tests/unit/job/seedingJobCreator/SeedingJobCreator.spec.ts
+++ b/tests/unit/job/seedingJobCreator/SeedingJobCreator.spec.ts
@@ -96,7 +96,7 @@ describe('SeedingJobCreator', () => {
       readProductGeometryMock.mockResolvedValue(productGeometry);
       catalogClientMock.findLayer.mockResolvedValue(layer);
       vi.useFakeTimers().setSystemTime(new Date('2024-11-05T13:50:27Z'));
-      mapproxyClientMock.getCacheName.mockResolvedValue(layerCacheName);
+      mapproxyClientMock.getRedisCacheName.mockResolvedValue(layerCacheName);
       jobManagerClientMock.createJob.mockResolvedValue({ id: seedJobId, taskIds: [taskId] });
 
       nock(baseUrl)
@@ -105,7 +105,7 @@ describe('SeedingJobCreator', () => {
 
       const res = await seedingJobCreator.create(seedJobParams);
 
-      expect(mapproxyClientMock.getCacheName).toHaveBeenCalledWith({ layerName: seedJobParams.layerName, cacheType: LayerCacheType.REDIS });
+      expect(mapproxyClientMock.getRedisCacheName).toHaveBeenCalledWith({ layerName: seedJobParams.layerName, cacheType: LayerCacheType.REDIS });
       expect(queueClientMock.jobManagerClient.createJob).toHaveBeenCalledWith(seedJob);
       expect(res).toBeUndefined();
     });
@@ -183,7 +183,7 @@ describe('SeedingJobCreator', () => {
       readProductGeometryMock.mockResolvedValue(productGeometry);
       catalogClientMock.findLayer.mockResolvedValue(layer);
       vi.useFakeTimers().setSystemTime(new Date('2024-11-05T13:50:27Z'));
-      mapproxyClientMock.getCacheName.mockResolvedValue(layerCacheName);
+      mapproxyClientMock.getRedisCacheName.mockResolvedValue(layerCacheName);
       jobManagerClientMock.createJob.mockResolvedValue({ id: seedJobId, taskIds: [taskId] });
 
       nock(baseUrl)
@@ -192,7 +192,7 @@ describe('SeedingJobCreator', () => {
 
       const res = await seedingJobCreator.create(seedJobParams);
 
-      expect(mapproxyClientMock.getCacheName).toHaveBeenCalledWith({ layerName: seedJobParams.layerName, cacheType: LayerCacheType.REDIS });
+      expect(mapproxyClientMock.getRedisCacheName).toHaveBeenCalledWith({ layerName: seedJobParams.layerName, cacheType: LayerCacheType.REDIS });
       expect(queueClientMock.jobManagerClient.createJob).toHaveBeenCalledWith(seedJob);
       expect(res).toBeUndefined();
     });
@@ -269,7 +269,7 @@ describe('SeedingJobCreator', () => {
 
       readProductGeometryMock.mockResolvedValue(productGeometry);
       vi.useFakeTimers().setSystemTime(new Date('2024-11-05T13:50:27Z'));
-      mapproxyClientMock.getCacheName.mockResolvedValue(layerCacheName);
+      mapproxyClientMock.getRedisCacheName.mockResolvedValue(layerCacheName);
       jobManagerClientMock.createJob.mockResolvedValue({ id: seedJobId, taskIds: [taskId] });
 
       nock(baseUrl)
@@ -278,7 +278,7 @@ describe('SeedingJobCreator', () => {
 
       const res = await seedingJobCreator.create(seedJobParams);
 
-      expect(mapproxyClientMock.getCacheName).toHaveBeenCalledWith({ layerName: seedJobParams.layerName, cacheType: LayerCacheType.REDIS });
+      expect(mapproxyClientMock.getRedisCacheName).toHaveBeenCalledWith({ layerName: seedJobParams.layerName, cacheType: LayerCacheType.REDIS });
       expect(queueClientMock.jobManagerClient.createJob).toHaveBeenCalledWith(seedJob);
       expect(res).toBeUndefined();
     });
@@ -286,7 +286,7 @@ describe('SeedingJobCreator', () => {
     it('should skip creating seeding job - no cache name found', async () => {
       const { seedingJobCreator, mapproxyClientMock, jobManagerClientMock } = seedingJobCreatorContext;
       const layerCacheName = 'not-exist-s3';
-      mapproxyClientMock.getCacheName.mockRejectedValue(new LayerCacheNotFoundError(layerCacheName, LayerCacheType.REDIS));
+      mapproxyClientMock.getRedisCacheName.mockRejectedValue(new LayerCacheNotFoundError(layerCacheName, LayerCacheType.REDIS));
 
       const seedJobParams: SeedJobParams = {
         ...seedJobParameters,
@@ -300,7 +300,7 @@ describe('SeedingJobCreator', () => {
     it('should skip creating seeding job - no footprint found', async () => {
       const { seedingJobCreator, mapproxyClientMock, jobManagerClientMock } = seedingJobCreatorContext;
       const layerCacheName = 'layer-name';
-      mapproxyClientMock.getCacheName.mockResolvedValue(layerCacheName);
+      mapproxyClientMock.getRedisCacheName.mockResolvedValue(layerCacheName);
 
       const seedJobParams: SeedJobParams = {
         ...seedJobParameters,
@@ -375,7 +375,7 @@ describe('SeedingJobCreator', () => {
 
         readProductGeometryMock.mockResolvedValue(productGeometry);
         vi.useFakeTimers().setSystemTime(new Date('2024-11-05T13:50:27Z'));
-        mapproxyClientMock.getCacheName.mockResolvedValue(layerCacheName);
+        mapproxyClientMock.getRedisCacheName.mockResolvedValue(layerCacheName);
         jobManagerClientMock.createJob.mockResolvedValue({ id: seedJobId, taskIds: [taskId] });
 
         nock(baseUrl)
@@ -387,7 +387,7 @@ describe('SeedingJobCreator', () => {
         };
 
         await expect(action()).resolves.not.toThrow();
-        expect(mapproxyClientMock.getCacheName).toHaveBeenCalledWith({ layerName: seedJobParams.layerName, cacheType: LayerCacheType.REDIS });
+        expect(mapproxyClientMock.getRedisCacheName).toHaveBeenCalledWith({ layerName: seedJobParams.layerName, cacheType: LayerCacheType.REDIS });
         expect(queueClientMock.jobManagerClient.createJob).toHaveBeenCalledWith(seedJob);
       });
 
@@ -433,7 +433,7 @@ describe('SeedingJobCreator', () => {
 
         readProductGeometryMock.mockResolvedValue(productGeometry);
         vi.useFakeTimers().setSystemTime(new Date('2024-11-05T13:50:27Z'));
-        mapproxyClientMock.getCacheName.mockResolvedValue(layerCacheName);
+        mapproxyClientMock.getRedisCacheName.mockResolvedValue(layerCacheName);
         jobManagerClientMock.createJob.mockResolvedValue({ id: seedJobId, taskIds: [taskId] });
 
         nock(baseUrl)
@@ -445,7 +445,7 @@ describe('SeedingJobCreator', () => {
         };
 
         await expect(action()).resolves.not.toThrow();
-        expect(mapproxyClientMock.getCacheName).toHaveBeenCalledWith({ layerName: seedJobParams.layerName, cacheType: LayerCacheType.REDIS });
+        expect(mapproxyClientMock.getRedisCacheName).toHaveBeenCalledWith({ layerName: seedJobParams.layerName, cacheType: LayerCacheType.REDIS });
         expect(queueClientMock.jobManagerClient.createJob).toHaveBeenCalledWith(seedJob);
       });
     });

--- a/tests/unit/job/seedingJobCreator/seedingJobCreatorSetup.ts
+++ b/tests/unit/job/seedingJobCreator/seedingJobCreatorSetup.ts
@@ -29,7 +29,7 @@ export const setupSeedingJobCreatorTest = async (): Promise<SeedingJobCreatorTes
     jobManagerClient: jobManagerClientMock,
   } as unknown as Mocked<QueueClient>;
 
-  const mapproxyClientMock = { getCacheName: vi.fn() } as unknown as Mocked<MapproxyApiClient>;
+  const mapproxyClientMock = { getRedisCacheName: vi.fn() } as unknown as Mocked<MapproxyApiClient>;
   const catalogClientMock = { update: vi.fn(), findLayer: vi.fn() } as unknown as Mocked<CatalogClient>;
 
   const seedingJobCreator = new SeedingJobCreator(

--- a/tests/unit/mocks/configMock.ts
+++ b/tests/unit/mocks/configMock.ts
@@ -132,6 +132,7 @@ const registerDefaultConfig = (): void => {
           createTasks: 'create-tasks',
           init: 'init',
           finalize: 'finalize',
+          delete: 'delete',
         },
       },
       ingestion: {
@@ -144,6 +145,9 @@ const registerDefaultConfig = (): void => {
           },
           swapUpdate: {
             type: 'Ingestion_Swap_Update',
+          },
+          deleteLayer: {
+            type: 'Delete_Layer',
           },
         },
         jobs: {
@@ -164,6 +168,11 @@ const registerDefaultConfig = (): void => {
             skipUncached: true,
             zoomThreshold: 16,
             maxTilesPerSeedTask: 500000,
+          },
+          tilesDeletion: {
+            type: 'tiles-deletion',
+            tileBatchSize: 10000,
+            taskBatchSize: 5,
           },
         },
       },

--- a/tests/unit/mocks/jobsMockData.ts
+++ b/tests/unit/mocks/jobsMockData.ts
@@ -3,6 +3,7 @@ import { zoomLevelToResolutionDeg } from '@map-colonies/mc-utils';
 import type { ICreateJobBody } from '@map-colonies/mc-priority-queue';
 import { OperationStatus } from '@map-colonies/mc-priority-queue';
 import type {
+  DeleteLayerJob,
   ExportJob,
   IngestionNewCreateTasksJob,
   IngestionNewFinalizeJob,
@@ -327,6 +328,38 @@ export const ingestionSwapUpdateFinalizeJob: IngestionSwapUpdateFinalizeJob = {
       displayPath: '391cf779-dfe0-42bd-9357-aaede47e4d37',
     },
   },
+};
+
+export const deleteLayerJob: DeleteLayerJob = {
+  id: 'a3e2c1d4-5b6f-4a7e-9c8d-1f2e3a4b5c6d',
+  resourceId: 'some_product',
+  version: '1.0',
+  type: 'Delete_Layer',
+  description: 'delete layer job',
+  parameters: {
+    approver: 'test-approver',
+  },
+  status: OperationStatus.IN_PROGRESS,
+  percentage: 0,
+  reason: '',
+  domain: RASTER_DOMAIN,
+  isCleaned: false,
+  priority: 1000,
+  expirationDate: new Date('2024-07-21T10:59:23.510Z'),
+  internalId: '89bc4f63-8608-40bf-b845-3cbd4c0c4e03',
+  producerName: 'string',
+  productName: 'test',
+  productType: RasterProductTypes.ORTHOPHOTO,
+  additionalIdentifiers: 'some-additional-identifiers',
+  taskCount: 1,
+  completedTasks: 0,
+  failedTasks: 0,
+  expiredTasks: 0,
+  pendingTasks: 0,
+  inProgressTasks: 1,
+  abortedTasks: 0,
+  created: '2024-07-21T10:59:23.510Z',
+  updated: '2024-07-21T10:59:23.510Z',
 };
 
 // Seed Task Options Mock Functions

--- a/tests/unit/mocks/polygonPartsManagerClientMock.ts
+++ b/tests/unit/mocks/polygonPartsManagerClientMock.ts
@@ -4,4 +4,5 @@ import type { PolygonPartsMangerClient } from '../../../src/httpClients/polygonP
 export const polygonPartsManagerClientMock = {
   process: vi.fn(),
   getAggregatedLayerMetadata: vi.fn(),
+  deleteEntities: vi.fn(),
 } as unknown as Mocked<PolygonPartsMangerClient>;

--- a/tests/unit/mocks/tasksMockData.ts
+++ b/tests/unit/mocks/tasksMockData.ts
@@ -1,5 +1,6 @@
 import { faker } from '@faker-js/faker';
 import type {
+  DeleteTaskParams,
   ExportFinalizeTaskParams,
   IngestionNewFinalizeTaskParams,
   IngestionSwapUpdateFinalizeTaskParams,
@@ -10,8 +11,8 @@ import type {
 import { ExportFinalizeType } from '@map-colonies/raster-shared';
 import type { ITaskResponse } from '@map-colonies/mc-priority-queue';
 import { OperationStatus } from '@map-colonies/mc-priority-queue';
-import type { ExportFinalizeTask, ExportInitTask } from '../../../src/utils/zod/schemas/job.schema';
-import { exportJob, ingestionNewJob, ingestionSwapUpdateJob, ingestionUpdateJob } from './jobsMockData';
+import type { DeleteTask, ExportFinalizeTask, ExportInitTask } from '../../../src/utils/zod/schemas/job.schema';
+import { deleteLayerJob, exportJob, ingestionNewJob, ingestionSwapUpdateJob, ingestionUpdateJob } from './jobsMockData';
 
 export const createFakeTask = <T>(taskOverride?: Partial<ITaskResponse<T>>, parameters?: T): ITaskResponse<T> => ({
   id: faker.string.uuid(),
@@ -32,6 +33,12 @@ export const createFakeTask = <T>(taskOverride?: Partial<ITaskResponse<T>>, para
 export const createTasksTaskForIngestionNew = createFakeTask<TaskBlockDuplicationParam>(
   { jobId: ingestionNewJob.id, type: 'create-tasks' },
   { blockDuplication: true }
+);
+
+// all metadata-deletion steps pending — the entry state of a fresh delete task
+export const deleteTaskForDeleteLayer: DeleteTask = createFakeTask<DeleteTaskParams>(
+  { jobId: deleteLayerJob.id, type: 'delete', status: OperationStatus.IN_PROGRESS },
+  { deleteFromCatalog: false, deleteFromGeoserver: false, deletePolygonParts: false, deleteFromMapproxy: false }
 );
 
 export const createTasksTaskForIngestionUpdate = createFakeTask<TaskBlockDuplicationParam>(

--- a/tests/unit/mocks/testCasesData.ts
+++ b/tests/unit/mocks/testCasesData.ts
@@ -1,5 +1,6 @@
 import type { IJobResponse, ITaskResponse } from '@map-colonies/mc-priority-queue';
 import {
+  deleteLayerJob,
   exportJob,
   ingestionNewJob,
   ingestionNewJobExtended,
@@ -9,6 +10,7 @@ import {
   ingestionUpdateJob,
 } from '../mocks/jobsMockData';
 import {
+  deleteTaskForDeleteLayer,
   finalizeTaskForExport,
   finalizeTaskForIngestionNew,
   finalizeTaskForIngestionSwapUpdate,
@@ -80,5 +82,15 @@ export const finalizeTestCases: JobProcessingTestCase[] = [
     taskType: finalizeTaskForExport.type,
     task: finalizeTaskForExport,
     instanceType: 'export',
+  },
+];
+
+export const deleteTestCases: JobProcessingTestCase[] = [
+  {
+    jobType: deleteLayerJob.type,
+    taskType: deleteTaskForDeleteLayer.type,
+    job: deleteLayerJob,
+    task: deleteTaskForDeleteLayer,
+    instanceType: 'ingestion',
   },
 ];

--- a/tests/unit/utils/configUtil.spec.ts
+++ b/tests/unit/utils/configUtil.spec.ts
@@ -1,8 +1,15 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import { MissingConfigError } from '../../../src/common/errors';
-import type { PollingJobs } from '../../../src/common/interfaces';
-import { validateAndGetHandlersTokens } from '../../../src/utils/configUtil';
+import type { PollingJobs, PollingTasks } from '../../../src/common/interfaces';
+import { getPollingTaskTypes, validateAndGetHandlersTokens } from '../../../src/utils/configUtil';
 import { registerDefaultConfig } from '../mocks/configMock';
+
+const pollingTasks: PollingTasks = {
+  createTasks: 'create-tasks',
+  init: 'init',
+  finalize: 'finalize',
+  delete: 'delete',
+};
 
 describe('configUtil', () => {
   beforeEach(() => {
@@ -18,6 +25,7 @@ describe('configUtil', () => {
           new: { type: 'Ingestion_New' },
           update: { type: 'Ingestion_Update' },
           swapUpdate: { type: 'Ingestion_Swap_Update' },
+          deleteLayer: { type: 'Delete_Layer' },
         };
 
         const result = validateAndGetHandlersTokens(ingestionConfig, instanceType);
@@ -26,7 +34,20 @@ describe('configUtil', () => {
           Ingestion_New: ingestionConfig.new?.type,
           Ingestion_Update: ingestionConfig.update?.type,
           Ingestion_Swap_Update: ingestionConfig.swapUpdate?.type,
+          Delete_Layer: ingestionConfig.deleteLayer?.type,
         });
+      });
+
+      it('should throw an error if the "delete layer" job type is not found in the config', () => {
+        const ingestionConfig = {
+          new: { type: 'Ingestion_New' },
+          update: { type: 'Ingestion_Update' },
+          swapUpdate: { type: 'Ingestion_Swap_Update' },
+        } as unknown as PollingJobs;
+
+        const action = () => validateAndGetHandlersTokens(ingestionConfig, instanceType);
+
+        expect(action).toThrow(MissingConfigError);
       });
 
       it('should throw an error if one of the "new" job type is not found in the config', () => {
@@ -107,6 +128,21 @@ describe('configUtil', () => {
 
         expect(action).toThrow(MissingConfigError);
       });
+    });
+  });
+
+  describe('getPollingTaskTypes', () => {
+    it('should return create, init, finalize and delete task types for the ingestion domain', () => {
+      const result = getPollingTaskTypes(pollingTasks, 'ingestion');
+
+      expect(result).toEqual([pollingTasks.createTasks, pollingTasks.init, pollingTasks.finalize, pollingTasks.delete]);
+    });
+
+    it('should return create, init and finalize task types (without delete) for the export domain', () => {
+      const result = getPollingTaskTypes(pollingTasks, 'export');
+
+      expect(result).toEqual([pollingTasks.createTasks, pollingTasks.init, pollingTasks.finalize]);
+      expect(result).not.toContain(pollingTasks.delete);
     });
   });
 });

--- a/tests/unit/utils/s3Service.spec.ts
+++ b/tests/unit/utils/s3Service.spec.ts
@@ -18,7 +18,8 @@ describe('s3Service', () => {
     accessKeyId: 'accessKeyId',
     secretAccessKey: 'secretAccessKey',
     endpointUrl: 'http://localhost:9000',
-    bucket: 'bucket',
+    artifactsBucket: 'artifactsBucket',
+    tilesBucket: 'tilesBucket',
     objectKey: 'objectKey',
     sslEnabled: false,
   };
@@ -41,7 +42,7 @@ describe('s3Service', () => {
     createReadStreamSpy = vi.spyOn(fs, 'createReadStream').mockReturnValue(mockReadStream as unknown as fs.ReadStream);
 
     uploadDoneSpy = vi.fn().mockResolvedValue({
-      Bucket: mockS3Config.bucket,
+      Bucket: mockS3Config.artifactsBucket,
       Key: testS3Key,
     });
 
@@ -59,14 +60,14 @@ describe('s3Service', () => {
       uploadDoneSpy.mockImplementation(() => {
         const index = callCount++;
         return Promise.resolve({
-          Bucket: mockS3Config.bucket,
+          Bucket: mockS3Config.artifactsBucket,
           Key: testFiles[index % testFiles.length]!.s3Key,
         });
       });
     });
 
     it('should upload multiple files to S3', async () => {
-      const expectedUrls = testFiles.map((file) => `${mockS3Config.endpointUrl}/${mockS3Config.bucket}/${file.s3Key}`);
+      const expectedUrls = testFiles.map((file) => `${mockS3Config.endpointUrl}/${mockS3Config.artifactsBucket}/${file.s3Key}`);
 
       const s3ClientCtorArgs = {
         credentials: {
@@ -92,7 +93,7 @@ describe('s3Service', () => {
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           client: expect.any(S3Client),
           params: {
-            Bucket: mockS3Config.bucket,
+            Bucket: mockS3Config.artifactsBucket,
             Key: file.s3Key,
             ContentType: file.contentType,
             Body: mockReadStream,
@@ -106,7 +107,7 @@ describe('s3Service', () => {
     });
 
     it('should upload single file to S3', async () => {
-      const expectedUrl = `${mockS3Config.endpointUrl}/${mockS3Config.bucket}/${testFiles[0]!.s3Key}`;
+      const expectedUrl = `${mockS3Config.endpointUrl}/${mockS3Config.artifactsBucket}/${testFiles[0]!.s3Key}`;
       const s3ClientCtorArgs = {
         credentials: {
           accessKeyId: mockS3Config.accessKeyId,
@@ -128,7 +129,7 @@ describe('s3Service', () => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         client: expect.any(S3Client),
         params: {
-          Bucket: mockS3Config.bucket,
+          Bucket: mockS3Config.artifactsBucket,
           Key: testFiles[0]!.s3Key,
           ContentType: testFiles[0]!.contentType,
           Body: mockReadStream,


### PR DESCRIPTION
| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✖      |
| New feature     | ✔      |
| Breaking change | ✖      |
| Deprecations    | ✖      |
| Documentation   | ✖      |
| Tests added     | ✔      |
| Chore           | ✖      |

Related issues: MAPCO-7285

## Overview

Implements the **full-layer deletion** flow in the overseer. A `Delete_Layer` job with a `delete` task drives ordered removal of a layer's metadata across every system that references it, then hands tile (and, later, artifact) cleanup off to the Cleaner via a downstream `tiles-deletion` task.

## What this adds

**Per-client deletion methods**
- `CatalogClient.deleteRecord` — remove the catalog record.
- `GeoserverClient`: `unpublishLayer` → performs the geoserver unpublish.
- `PolygonPartsMangerClient.deleteEntities` — drop the polygon-parts entities.
- `MapproxyApiClient.removeLayer` — remove the layer from mapproxy (treats a 404 as already-removed / idempotent).

**Storage / cache plumbing**
- Split the S3 bucket config into `artifactsBucket` and `tilesBucket` (helm + config), guarded by `tilesStorageProvider`.
- `MapproxyApiClient.getLayerCache` returns the layer's cache object (directory + bucket) for the configured cache type, or `undefined` on 404.

**`DeleteLayerHandler`** (`Delete_Layer` / `delete`)
- Runs the four metadata-deletion steps in order, persisting each step's completion flag immediately so a redelivered task resumes from where it failed (does not repeat completed steps).
- Resolves the tiles location from the mapproxy cache **before** any deletion step and persists it into the task params — the `deleteFromMapproxy` step destroys the cache, so a redelivered task reads the location from its own params instead of re-querying a layer that no longer exists.
- Derives the Cleaner path from the mapproxy cache `directory` (not the catalogId): **S3** drops the leading slash (object keys are lstripped by mapproxy), **FS** drops the first segment (the mapproxy PVC mount) so the Cleaner rejoins its own base path. S3 also carries the bucket (cache `bucket_name`, falling back to configured `tilesBucket`).
- Creates the downstream `tiles-deletion` cleaner task once all metadata steps complete, with an idempotency guard against duplicate creation on redelivery.

**Wiring**
- Registered the `Delete_Layer` job and `delete` task in the polling config and DI container.
- `configUtil`: extracted per-domain polling-task-type selection into `getPollingTaskTypes`.

## Notes / follow-ups
- **Artifacts-deletion task is deferred** (`TODO` in the handler): mapproxy's `GET /layer` does not expose artifacts, so the existence source-of-truth and params shape are unresolved.

## Tests
- Unit coverage for every new client method, the bucket-config split, `getLayerCache`, and the full `DeleteLayerHandler` flow (step ordering + per-step persistence, redelivery skip, FS/S3 path + bucket resolution, cleaner-task idempotency, and unresolvable-cache rejection).
- Full unit suite green (228 tests); `tsc --noEmit`, eslint, and prettier clean.
