### PR TITLE
fix: default configManagement.offlineMode to true (MAPCO-8284)

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -123,7 +123,7 @@ tracing:
   url: ""
 
 configManagement:
-  offlineMode: false
+  offlineMode: true
   name: 'overseer'
   version: 'latest'
   serverUrl: 'http://localhost:8080/api'


### PR DESCRIPTION
Every consumer of this chart in helm-charts (dev/qa/integration, ingestion-trigger, raster-catalog-manager too) has had to manually override \`configManagement.offlineMode: false → true\`. The shipped default of \`false\` points at \`serverUrl: http://localhost:8080/api\` — a config server that doesn't exist in any of our current environments, so leaving the default unset risks the app trying to fetch remote config on startup and hanging.

Flips the chart's own default to the safe value so umbrella charts don't have to keep rediscovering and overriding this.

| Field | Before | After |
|---|---|---|
| configManagement.offlineMode | false | **true** |

No other configManagement fields touched.