### PR TITLE
fix: missing newline before S3_ENDPOINT_URL breaks configmap YAML when gpkgProvider=S3

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
   {{ end }}
   TELEMETRY_METRICS_BUCKETS: {{ .Values.mclabels.prometheus.buckets | toJson | quote }}
   {{- if eq (upper $storage.gpkgProvider) "S3" }}
-  {{- $s3HttpProtocol := ternary "https://" "http://" $storage.s3.sslEnabled -}}
+  {{- $s3HttpProtocol := ternary "https://" "http://" $storage.s3.sslEnabled }}
   S3_ENDPOINT_URL: {{ printf "%s%s" $s3HttpProtocol $storage.s3.endpointUrl | quote }}
   S3_ARTIFACTS_BUCKET: {{ $storage.s3.artifactsBucket | quote }}
   S3_SSL_ENABLED: {{ $storage.s3.sslEnabled | quote }}


### PR DESCRIPTION
The S3 block in \`helm/templates/configmap.yaml\` over-trims whitespace, deleting the newline before \`S3_ENDPOINT_URL\`. That glues it onto the previous line, producing invalid YAML — breaks every deploy where \`gpkgProvider: S3\` (confirmed: helm-charts \`qa\` and \`integration\`).

Fix: drop the trailing \`-}}\` so the newline is preserved.

Verified locally — chart now renders cleanly against qa's real values.