### PR TITLE
fix(deps): upgrade @map-colonies/raster-shared to ^8.3.0 (MAPCO-11282)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@map-colonies/mc-priority-queue": "^9.1.2",
         "@map-colonies/mc-utils": "^6.0.1",
         "@map-colonies/prometheus": "^1.0.0",
-        "@map-colonies/raster-shared": "^8.3.0-alpha.2",
+        "@map-colonies/raster-shared": "^8.3.0",
         "@map-colonies/read-pkg": "^1.0.0",
         "@map-colonies/schemas": "^1.18.0",
         "@map-colonies/shapefile-reader": "^1.0.1",
@@ -6593,9 +6593,9 @@
       }
     },
     "node_modules/@map-colonies/raster-shared": {
-      "version": "8.3.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.3.0-alpha.2.tgz",
-      "integrity": "sha512-P2p0MddLonzxsG/MSkcKopfI05JsaWxe9BpfYPrVllZ7wCbrzyBUnsYsfP3Rl6jHeNlqWWPCJdHkpzvgTi0FOQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/@map-colonies/raster-shared/-/raster-shared-8.3.0.tgz",
+      "integrity": "sha512-5faR0iBC9Dpxm7Z8fY+3d+5oolHqVk/urXeOq3nHuIEMOvwRT2TrTr9fmt6TK8DaCjyQXBeEU1nijvuPLHmrEw==",
       "license": "ISC",
       "dependencies": {
         "@map-colonies/mc-priority-queue": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@map-colonies/mc-priority-queue": "^9.1.2",
     "@map-colonies/mc-utils": "^6.0.1",
     "@map-colonies/prometheus": "^1.0.0",
-    "@map-colonies/raster-shared": "^8.3.0-alpha.2",
+    "@map-colonies/raster-shared": "^8.3.0",
     "@map-colonies/read-pkg": "^1.0.0",
     "@map-colonies/schemas": "^1.18.0",
     "@map-colonies/shapefile-reader": "^1.0.1",


### PR DESCRIPTION
## Summary
MAPCO-11282 — upgrade `@map-colonies/raster-shared` to the official **v8.3.0** release.

`^8.3.0-alpha.2` → `^8.3.0`

## Tests
Baseline captured on unmodified `origin/master` first, so a pre-existing failure couldn't be mistaken for a regression.

| | Baseline | After bump |
|---|---|---|
| Tests | 234 passed | 234 passed |

`package-lock.json` regenerated — installed version confirmed as `8.3.0`.
